### PR TITLE
Quantstamp Audit Remediations: pstAVAX, ggAVAX, WithdrawQueue

### DIFF
--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -52,6 +52,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	Storage public store;
 
 	uint256 private maxRequestsPerStakingDeposit;
+	uint256 private minUnstakeOnBehalfOfAmt;
 
 	event UnstakeRequested(uint256 indexed requestId, address indexed requester, uint256 shares, uint256 expectedAssets, uint48 claimableTime);
 	event RequestFulfilled(bytes32 indexed source, uint256 indexed requestId, uint256 assets);
@@ -83,6 +84,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	error ZeroShares();
 	error InvalidRedemptionAmount();
 	error InvalidYieldAmounts();
+	error MinimumSharesNotMet();
 
 	/// @custom:oz-upgrades-unsafe-allow constructor
 	constructor() {
@@ -103,6 +105,9 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		expirationDelay = _expirationDelay;
 		store = Storage(storageAddress);
 
+		maxRequestsPerStakingDeposit = 50;
+		minUnstakeOnBehalfOfAmt = 0.01 ether;
+
 		emit ContractInitialized(tokenggAVAXAddress, _unstakeDelay, _expirationDelay);
 	}
 
@@ -122,6 +127,9 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	}
 
 	function requestUnstakeOnBehalfOf(uint256 shares, address requester) external returns (uint256 requestId) {
+		if (shares < minUnstakeOnBehalfOfAmt) {
+			revert MinimumSharesNotMet();
+		}
 		return _requestUnstake(shares, msg.sender, requester);
 	}
 
@@ -560,6 +568,18 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		maxRequestsPerStakingDeposit = newLimit;
 	}
 
+	/// @notice Set the minimum unstake amount on behalf of (admin only)
+	/// @param newMinUnstakeOnBehalfOfAmt The new minimum unstake amount on behalf of
+	function setMinUnstakeOnBehalfOfAmt(uint256 newMinUnstakeOnBehalfOfAmt) external onlyRole(DEFAULT_ADMIN_ROLE) {
+		minUnstakeOnBehalfOfAmt = newMinUnstakeOnBehalfOfAmt;
+	}
+
+	/// @notice Get the minimum unstake amount on behalf of
+	/// @return The minimum unstake amount on behalf of
+	function getMinUnstakeOnBehalfOfAmt() external view returns (uint256) {
+		return minUnstakeOnBehalfOfAmt;
+	}
+
 	/// @notice Set the unstake delay (admin only)
 	/// @param newUnstakeDelay The new unstake delay in seconds
 	function setUnstakeDelay(uint48 newUnstakeDelay) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -590,11 +610,29 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		return block.timestamp >= req.claimableTime && block.timestamp < req.expirationTime;
 	}
 
-	/// @notice Get all unstake request IDs for a specific user
-	/// @param user The address of the user
-	/// @return Array of all request IDs belonging to that user
-	function getRequestsByOwner(address user) external view returns (uint256[] memory) {
-		return requestsByOwner[user].values();
+	/// @notice Get unstake request IDs for a user, paginated
+	/// @param user   The address of the user
+	/// @param offset How many entries to skip (0-based)
+	/// @param limit  Max number of entries to return; if 0, returns all after offset
+	/// @return ids   Array of request IDs in the requested slice
+	function getRequestsByOwner(address user, uint256 offset, uint256 limit) external view returns (uint256[] memory ids) {
+		uint256 total = requestsByOwner[user].length();
+
+		if (offset >= total) {
+			return new uint256[](0);
+		}
+
+		// if limit==0, return everything from offset; otherwise cap at total
+		uint256 end = limit == 0 ? total : offset + limit;
+		if (end > total) {
+			end = total;
+		}
+
+		uint256 count = end - offset;
+		ids = new uint256[](count);
+		for (uint256 i = 0; i < count; i++) {
+			ids[i] = requestsByOwner[user].at(offset + i);
+		}
 	}
 
 	/// @notice Get how many unstake requests are still waiting to be fulfilled

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -51,7 +51,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	TokenggAVAX public tokenggAVAX;
 	Storage public store;
 
-	uint256 private maxPendingRequestsLimit;
+	uint256 private maxRequestsPerStakingDeposit;
 
 	event UnstakeRequested(uint256 indexed requestId, address indexed requester, uint256 shares, uint256 expectedAssets, uint48 claimableTime);
 	event RequestFulfilled(bytes32 indexed source, uint256 indexed requestId, uint256 assets);
@@ -353,7 +353,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 
 		// Process pending requests from front of queue, removing fulfilled requests and then leave the money in the contract if still more to process
 		uint256 requestsProcessed = 0;
-		while (pendingRequests.length() > 0 && requestsProcessed < maxPendingRequestsLimit) {
+		while (pendingRequests.length() > 0 && requestsProcessed < maxRequestsPerStakingDeposit) {
 			uint256 requestId = uint256(pendingRequestsQueue.front());
 			if (!pendingRequests.contains(requestId)) {
 				pendingRequestsQueue.popFront();
@@ -616,14 +616,14 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 
 	/// @notice Get the current max pending requests limit
 	/// @return The current max pending requests limit
-	function getMaxPendingRequestsLimit() external view returns (uint256) {
-		return maxPendingRequestsLimit;
+	function getMaxRequestsPerStakingDeposit() external view returns (uint256) {
+		return maxRequestsPerStakingDeposit;
 	}
 
 	/// @notice Set the max pending requests limit (admin only)
 	/// @param newLimit The new max pending requests limit
-	function setMaxPendingRequestsLimit(uint256 newLimit) external onlyRole(DEFAULT_ADMIN_ROLE) {
-		maxPendingRequestsLimit = newLimit;
+	function setMaxRequestsPerStakingDeposit(uint256 newLimit) external onlyRole(DEFAULT_ADMIN_ROLE) {
+		maxRequestsPerStakingDeposit = newLimit;
 	}
 
 	/// @notice Set the unstake delay (admin only)

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -118,71 +118,11 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	/// @param shares How many stAVAX tokens you want to unstake
 	/// @return requestId Your unique request ID for tracking
 	function requestUnstake(uint256 shares) external returns (uint256 requestId) {
-		if (shares == 0) {
-			revert ZeroShares();
-		}
-
-		if (tokenggAVAX.balanceOf(msg.sender) < shares) {
-			revert InsufficientTokenBalance();
-		}
-
-		uint256 expectedAssets = tokenggAVAX.convertToAssets(shares);
-
-		ERC20(address(tokenggAVAX)).safeTransferFrom(msg.sender, address(this), shares);
-
-		requestId = nextRequestId++;
-		uint48 currentTime = uint48(block.timestamp);
-
-		requests[requestId] = UnstakeRequest({
-			requester: msg.sender,
-			shares: shares,
-			expectedAssets: expectedAssets,
-			requestTime: currentTime,
-			claimableTime: currentTime + unstakeDelay,
-			expirationTime: currentTime + unstakeDelay + expirationDelay,
-			allocatedFunds: 0
-		});
-
-		requestsByOwner[msg.sender].add(requestId);
-		pendingRequests.add(requestId);
-		pendingRequestsQueue.pushBack(bytes32(requestId));
-
-		emit UnstakeRequested(requestId, msg.sender, shares, expectedAssets, currentTime + unstakeDelay);
+		return _requestUnstake(shares, msg.sender, msg.sender);
 	}
 
 	function requestUnstakeOnBehalfOf(uint256 shares, address requester) external returns (uint256 requestId) {
-		if (shares == 0) {
-			revert ZeroShares();
-		}
-
-		// We want to transfer shares from caller (NOT requester) to this contract
-		if (tokenggAVAX.balanceOf(msg.sender) < shares) {
-			revert InsufficientTokenBalance();
-		}
-
-		uint256 expectedAssets = tokenggAVAX.convertToAssets(shares);
-
-		// We want to transfer shares from caller (NOT requester) to this contract
-		ERC20(address(tokenggAVAX)).safeTransferFrom(msg.sender, address(this), shares);
-
-		requestId = nextRequestId++;
-		uint48 currentTime = uint48(block.timestamp);
-
-		requests[requestId] = UnstakeRequest({
-			requester: requester,
-			shares: shares,
-			expectedAssets: expectedAssets,
-			requestTime: currentTime,
-			claimableTime: currentTime + unstakeDelay,
-			expirationTime: currentTime + unstakeDelay + expirationDelay,
-			allocatedFunds: 0
-		});
-
-		requestsByOwner[requester].add(requestId);
-		pendingRequests.add(requestId);
-		pendingRequestsQueue.pushBack(bytes32(requestId));
-
-		emit UnstakeRequested(requestId, requester, shares, expectedAssets, currentTime + unstakeDelay);
+		return _requestUnstake(shares, msg.sender, requester);
 	}
 
 	/// @notice Claim your AVAX after your unstake request is fulfilled
@@ -759,6 +699,44 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		uint256 totalAssets = tokenggAVAX.totalAssets();
 		uint256 stakingTotal = tokenggAVAX.stakingTotalAssets();
 		return totalAssets > stakingTotal ? totalAssets - stakingTotal : 0;
+	}
+
+	/// @dev Internal function implementing the core unstake request logic
+	/// @param shares The number of shares to unstake
+	/// @param shareProvider The address that provides the shares (caller)
+	/// @param requester The address that will own the request and receive the funds
+	/// @return requestId The unique identifier for the created request
+	function _requestUnstake(uint256 shares, address shareProvider, address requester) internal returns (uint256 requestId) {
+		if (shares == 0) {
+			revert ZeroShares();
+		}
+
+		if (tokenggAVAX.balanceOf(shareProvider) < shares) {
+			revert InsufficientTokenBalance();
+		}
+
+		uint256 expectedAssets = tokenggAVAX.convertToAssets(shares);
+
+		ERC20(address(tokenggAVAX)).safeTransferFrom(shareProvider, address(this), shares);
+
+		requestId = nextRequestId++;
+		uint48 currentTime = uint48(block.timestamp);
+
+		requests[requestId] = UnstakeRequest({
+			requester: requester,
+			shares: shares,
+			expectedAssets: expectedAssets,
+			requestTime: currentTime,
+			claimableTime: currentTime + unstakeDelay,
+			expirationTime: currentTime + unstakeDelay + expirationDelay,
+			allocatedFunds: 0
+		});
+
+		requestsByOwner[requester].add(requestId);
+		pendingRequests.add(requestId);
+		pendingRequestsQueue.pushBack(bytes32(requestId));
+
+		emit UnstakeRequested(requestId, requester, shares, expectedAssets, currentTime + unstakeDelay);
 	}
 
 	/// @dev Storage gap for future upgrades

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -64,6 +64,8 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	event BatchExpiredFundsReclaimed(address indexed requester, uint256 totalAmount, uint256 requestsProcessed);
 	event QueueCleaned(bytes32 indexed reason, uint256 indexed requestId);
 	event ContractInitialized(address indexed tokenggAVAX, uint48 unstakeDelay, uint48 expirationDelay);
+	event InsufficientLiquidity(uint256 availableAssets, uint256 requiredAssets);
+	event PendingRequestsNotProcesses(uint256 pendingRequests);
 
 	error DirectAVAXDepositsNotSupported();
 	error InsufficientAVAXBalance();
@@ -365,6 +367,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 
 			uint256 withdrawQueueAvailableAssets = address(this).balance > totalAllocatedFunds ? address(this).balance - totalAllocatedFunds : 0;
 			if (withdrawQueueAvailableAssets + ggAVAXAvailableAssets < req.expectedAssets) {
+				emit InsufficientLiquidity(withdrawQueueAvailableAssets + ggAVAXAvailableAssets, req.expectedAssets);
 				return;
 			}
 
@@ -380,6 +383,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 				}
 
 				if (depositAmountIncludingFees > withdrawQueueAvailableAssets) {
+					emit InsufficientLiquidity(withdrawQueueAvailableAssets, depositAmountIncludingFees);
 					return;
 				}
 
@@ -423,14 +427,23 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 					excessAVAX += assetsReturned - req.expectedAssets;
 				}
 				requestsProcessed++;
-			} catch {
-				// stAVAX doesn't have enough liquidity for this request, stop processing
-				// Leave this request in the pending set for next time
-				break;
+			} catch (bytes memory reason) {
+				// Check if this is specifically an insufficient liquidity error
+				if (reason.length >= 4 && bytes4(reason) == TokenggAVAX.InsufficientLiquidity.selector) {
+					// stAVAX doesn't have enough liquidity for this request, stop processing
+					// Leave this request in the pending set for next time
+					break;
+				}
+				// For other errors, bubble up rather than assuming liquidity issue
+				// This preserves the original error for debugging
+				assembly {
+					revert(add(reason, 0x20), mload(reason))
+				}
 			}
 		}
 
 		if (pendingRequests.length() != 0) {
+			emit PendingRequestsNotProcesses(pendingRequests.length());
 			return;
 		}
 

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -371,10 +371,17 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 				uint256 proRatedRewardAmt = amountToDeposit.mulWadDown(rewardToBaseRatio);
 				uint256 proRatedBaseAmt = amountToDeposit - proRatedRewardAmt;
 
-				if (baseAmt > 0) {
+				if (proRatedBaseAmt > baseAmt ) {
+					baseAmt = 0;
+				}
+				else {
 					baseAmt -= proRatedBaseAmt;
 				}
-				if (rewardAmt > 0) {
+
+				if (proRatedRewardAmt > rewardAmt) {
+					rewardAmt = 0;
+				}
+				else {
 					rewardAmt -= proRatedRewardAmt;
 				}
 

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -311,6 +311,9 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 			uint256 withdrawQueueAvailableAssets = address(this).balance > totalAllocatedFunds ? address(this).balance - totalAllocatedFunds : 0;
 			if (withdrawQueueAvailableAssets + ggAVAXAvailableAssets < req.expectedAssets) {
 				emit InsufficientLiquidity(withdrawQueueAvailableAssets + ggAVAXAvailableAssets, req.expectedAssets);
+				if (excessAVAX > 0) {
+					_depositYield(excessAVAX);
+				}
 				return;
 			}
 
@@ -327,6 +330,9 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 
 				if (depositAmountIncludingFees > withdrawQueueAvailableAssets) {
 					emit InsufficientLiquidity(withdrawQueueAvailableAssets, depositAmountIncludingFees);
+					if (excessAVAX > 0) {
+						_depositYield(excessAVAX);
+					}
 					return;
 				}
 
@@ -386,7 +392,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		}
 
 		if (excessAVAX > 0) {
-			tokenggAVAX.depositYield{value: excessAVAX}(bytes32("WITHDRAW_QUEUE"));
+			_depositYield(excessAVAX);
 		}
 
 		if (pendingRequests.length() != 0) {
@@ -723,6 +729,12 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	/// @param value The amount of AVAX to deposit
 	function _depositToGGAVAX(uint256 baseAmt, uint256 rewardAmt, bytes32 source, uint256 value) internal {
 		tokenggAVAX.depositFromStaking{value: value}(baseAmt, rewardAmt, source);
+	}
+
+	/// @notice Deposit AVAX to ggAVAX via yield method
+	/// @param value The amount of AVAX to deposit
+	function _depositYield(uint256 value) internal {
+		tokenggAVAX.depositYield{value: value}(bytes32("WITHDRAW_QUEUE"));
 	}
 
 	/// @notice Get the amount of AVAX available in ggAVAX for redemption

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -156,7 +156,6 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		uint256 amount = req.allocatedFunds;
 
 		// Clean up all request data
-		req.allocatedFunds = 0;
 		totalAllocatedFunds -= amount;
 		fulfilledRequests.remove(requestId);
 
@@ -225,14 +224,10 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 			uint256 avaxAmount = req.allocatedFunds;
 
 			// Update accounting BEFORE external call (checks-effects-interactions)
-			req.allocatedFunds = 0;
 			totalAllocatedFunds -= avaxAmount;
 
 			// Remove from fulfilled queue BEFORE external call
 			fulfilledRequests.remove(requestId);
-
-			// Store necessary data before cleanup
-			address requester = req.requester;
 
 			// Clean up request data BEFORE external call
 			requestsByOwner[msg.sender].remove(requestId);
@@ -242,7 +237,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 			sharesToReturn = tokenggAVAX.depositAVAX{value: avaxAmount}();
 
 			// Emit event after we know sharesToReturn
-			emit RequestCancelled(requestId, requester, sharesToReturn);
+			emit RequestCancelled(requestId, msg.sender, sharesToReturn);
 		} else {
 			revert RequestNotPending();
 		}
@@ -272,7 +267,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 
 	/// @notice Deposit AVAX to help fulfill pending unstake requests
 	/// @dev Uses the deposited AVAX to fulfill waiting requests, sends excess back to stAVAX
-	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt, bytes32 source) public payable onlyRole(DEPOSITOR_ROLE) {
+	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt, bytes32 source) external payable onlyRole(DEPOSITOR_ROLE) {
 		// Validate that the sum of baseAmt and rewardAmt equals msg.value
 		if (baseAmt + rewardAmt != msg.value) {
 			revert InvalidYieldAmounts();
@@ -430,7 +425,6 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 			reclaimedAmount = req.allocatedFunds;
 
 			// Clean up all request data
-			req.allocatedFunds = 0;
 			totalAllocatedFunds -= reclaimedAmount;
 			fulfilledRequests.remove(requestId);
 			requestsByOwner[requester].remove(requestId);

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -442,13 +442,13 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 			}
 		}
 
+		if (excessAVAX > 0) {
+			tokenggAVAX.depositYield{value: excessAVAX}(bytes32("WITHDRAW_QUEUE"));
+		}
+
 		if (pendingRequests.length() != 0) {
 			emit PendingRequestsNotProcesses(pendingRequests.length());
 			return;
-		}
-
-		if (excessAVAX > 0) {
-			tokenggAVAX.depositYield{value: excessAVAX}(bytes32("WITHDRAW_QUEUE"));
 		}
 
 		// Handle any remaining amounts after processing all pending requests

--- a/contracts/contract/WithdrawQueue.sol
+++ b/contracts/contract/WithdrawQueue.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import {IWAVAX} from "../interface/IWAVAX.sol";
 import {TokenggAVAX} from "./tokens/TokenggAVAX.sol";
+import {Storage} from "./Storage.sol";
 
 import {ERC20} from "@rari-capital/solmate/src/tokens/ERC20.sol";
 
@@ -48,6 +49,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	uint48 public unstakeDelay;
 	uint48 public expirationDelay;
 	TokenggAVAX public tokenggAVAX;
+	Storage public store;
 
 	uint256 private maxPendingRequestsLimit;
 
@@ -89,7 +91,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 	/// @param tokenggAVAXAddress The address of the stAVAX token contract
 	/// @param _unstakeDelay How long users must wait before they can claim their AVAX
 	/// @param _expirationDelay How long after claiming period before requests expire
-	function initialize(address payable tokenggAVAXAddress, uint48 _unstakeDelay, uint48 _expirationDelay) public initializer {
+	function initialize(address payable tokenggAVAXAddress, address storageAddress, uint48 _unstakeDelay, uint48 _expirationDelay) public initializer {
 		__ReentrancyGuard_init();
 		__AccessControl_init();
 		_grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -97,6 +99,7 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 		tokenggAVAX = TokenggAVAX(payable(tokenggAVAXAddress));
 		unstakeDelay = _unstakeDelay;
 		expirationDelay = _expirationDelay;
+		store = Storage(storageAddress);
 
 		emit ContractInitialized(tokenggAVAXAddress, _unstakeDelay, _expirationDelay);
 	}
@@ -367,25 +370,35 @@ contract WithdrawQueue is Initializable, ReentrancyGuardUpgradeable, AccessContr
 
 			// Determine if we need to deposit additional assets to ggAVAX
 			if (ggAVAXAvailableAssets < req.expectedAssets) {
-				uint256 amountToDeposit = req.expectedAssets - ggAVAXAvailableAssets;
-				uint256 proRatedRewardAmt = amountToDeposit.mulWadDown(rewardToBaseRatio);
-				uint256 proRatedBaseAmt = amountToDeposit - proRatedRewardAmt;
+				uint256 depositAmountIncludingFees = req.expectedAssets - ggAVAXAvailableAssets;
 
-				if (proRatedBaseAmt > baseAmt ) {
-					baseAmt = 0;
+				uint256 feeBips = store.getUint(keccak256(abi.encodePacked("ProtocolDAO.FeeBips")));
+
+				if (feeBips > 0 && rewardToBaseRatio > 0) {
+					uint256 scaleFactor = uint256(1 ether).mulDivUp(10000, 10000 - feeBips);
+					depositAmountIncludingFees = depositAmountIncludingFees.mulWadUp(scaleFactor);
 				}
-				else {
+
+				if (depositAmountIncludingFees > withdrawQueueAvailableAssets) {
+					return;
+				}
+
+				uint256 proRatedRewardAmt = depositAmountIncludingFees.mulWadDown(rewardToBaseRatio);
+				uint256 proRatedBaseAmt = depositAmountIncludingFees - proRatedRewardAmt;
+
+				if (proRatedBaseAmt > baseAmt) {
+					baseAmt = 0;
+				} else {
 					baseAmt -= proRatedBaseAmt;
 				}
 
 				if (proRatedRewardAmt > rewardAmt) {
 					rewardAmt = 0;
-				}
-				else {
+				} else {
 					rewardAmt -= proRatedRewardAmt;
 				}
 
-				_depositToGGAVAX(proRatedBaseAmt, proRatedRewardAmt, source, amountToDeposit);
+				_depositToGGAVAX(proRatedBaseAmt, proRatedRewardAmt, source, depositAmountIncludingFees);
 			}
 
 			// Try to redeem all shares from initial request

--- a/contracts/contract/tokens/TokenggAVAX.sol
+++ b/contracts/contract/tokens/TokenggAVAX.sol
@@ -215,26 +215,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @param baseAmt The amount of liquid staker AVAX used to create a minipool
 	/// @param rewardAmt The rewards amount (in AVAX) earned from staking
 	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt) public payable onlySpecificRegisteredContract("MinipoolManager", msg.sender) {
-		ProtocolDAO protocolDAO = ProtocolDAO(getContractAddress("ProtocolDAO"));
-		Vault vault = Vault(getContractAddress("Vault"));
-
-		uint256 totalAmt = msg.value;
-		uint256 feeAmount = rewardAmt.mulDivDown(protocolDAO.getFeeBips(), 10000);
-		rewardAmt -= feeAmount;
-		if (totalAmt != (baseAmt + rewardAmt + feeAmount) || baseAmt > stakingTotalAssets) {
-			revert InvalidStakingDeposit();
-		}
-
-		if (feeAmount > 0) {
-			vault.depositAVAX{value: feeAmount}();
-			vault.transferAVAX("ClaimProtocolDAO", feeAmount);
-			emit FeeCollected(MINIPOOL_SOURCE, feeAmount);
-		}
-
-		stakingTotalAssets -= baseAmt;
-		IWAVAX(address(asset)).deposit{value: totalAmt - feeAmount}();
-
-		emit DepositedFromStaking(MINIPOOL_SOURCE, msg.sender, baseAmt, rewardAmt);
+		_depositFromStaking(baseAmt, rewardAmt, MINIPOOL_SOURCE);
 	}
 
 	/// @notice Allows users to deposit additional yield from activities such as MEV
@@ -242,26 +223,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @param rewardAmt The reward amount from yield activities
 	/// @param source The source of the additional yield (i.e. MEV)
 	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt, bytes32 source) public payable onlyRole(STAKER_ROLE) {
-		ProtocolDAO protocolDAO = ProtocolDAO(getContractAddress("ProtocolDAO"));
-		Vault vault = Vault(getContractAddress("Vault"));
-
-		uint256 totalAmt = msg.value;
-		uint256 feeAmt = rewardAmt.mulDivDown(protocolDAO.getFeeBips(), 10000);
-		rewardAmt -= feeAmt;
-
-		if (totalAmt != (baseAmt + rewardAmt + feeAmt) || baseAmt > stakingTotalAssets) {
-			revert InvalidStakingDeposit();
-		}
-
-		if (feeAmt > 0) {
-			vault.depositAVAX{value: feeAmt}();
-			vault.transferAVAX("ClaimProtocolDAO", feeAmt);
-			emit FeeCollected(source, feeAmt);
-		}
-
-		stakingTotalAssets -= baseAmt;
-		IWAVAX(address(asset)).deposit{value: totalAmt - feeAmt}();
-		emit DepositedFromStaking(source, msg.sender, baseAmt, rewardAmt);
+		_depositFromStaking(baseAmt, rewardAmt, source);
 	}
 
 	/// @notice Allows anyone to deposit yield to the contract
@@ -271,12 +233,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 		uint256 totalAmt = msg.value;
 		uint256 feeAmt = totalAmt.mulDivDown(protocolDAO.getFeeBips(), 10000);
 
-		Vault vault = Vault(getContractAddress("Vault"));
-		if (feeAmt > 0) {
-			vault.depositAVAX{value: feeAmt}();
-			vault.transferAVAX("ClaimProtocolDAO", feeAmt);
-			emit FeeCollected(source, feeAmt);
-		}
+		_collectProtocolFee(feeAmt, source);
 
 		IWAVAX(address(asset)).deposit{value: totalAmt - feeAmt}();
 		emit DepositedAdditionalYield(source, msg.sender, totalAmt, feeAmt);
@@ -526,6 +483,42 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @return uint256 Amount of AVAX required
 	function previewMint(uint256 shares) public view override whenTokenNotPaused(shares) returns (uint256) {
 		return super.previewMint(shares);
+	}
+
+	/// @dev Helper function to handle protocol fee collection for yield/deposit functions
+	/// @param feeAmount The amount of AVAX to collect as fees
+	/// @param source The source of the deposit (for event emission)
+	/// @return The amount of AVAX remaining after fee collection
+	function _collectProtocolFee(uint256 feeAmount, bytes32 source) internal returns (uint256) {
+		if (feeAmount > 0) {
+			Vault vault = Vault(getContractAddress("Vault"));
+			vault.depositAVAX{value: feeAmount}();
+			vault.transferAVAX("ClaimProtocolDAO", feeAmount);
+			emit FeeCollected(source, feeAmount);
+		}
+		return feeAmount;
+	}
+
+	/// @dev Internal function implementing the core deposit from staking logic
+	/// @param baseAmt The base amount being returned from staking/delegation
+	/// @param rewardAmt The reward amount from yield activities
+	/// @param source The source of the deposit (for event emission)
+	function _depositFromStaking(uint256 baseAmt, uint256 rewardAmt, bytes32 source) internal {
+		ProtocolDAO protocolDAO = ProtocolDAO(getContractAddress("ProtocolDAO"));
+
+		uint256 totalAmt = msg.value;
+		uint256 feeAmt = rewardAmt.mulDivDown(protocolDAO.getFeeBips(), 10000);
+		rewardAmt -= feeAmt;
+
+		if (totalAmt != (baseAmt + rewardAmt + feeAmt) || baseAmt > stakingTotalAssets) {
+			revert InvalidStakingDeposit();
+		}
+
+		_collectProtocolFee(feeAmt, source);
+
+		stakingTotalAssets -= baseAmt;
+		IWAVAX(address(asset)).deposit{value: totalAmt - feeAmt}();
+		emit DepositedFromStaking(source, msg.sender, baseAmt, rewardAmt);
 	}
 
 	/// @notice Function prior to a withdraw

--- a/contracts/contract/tokens/TokenggAVAX.sol
+++ b/contracts/contract/tokens/TokenggAVAX.sol
@@ -37,6 +37,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	error WithdrawForStakingDisabled();
 	error CannotGrantDefaultAdminRole();
 	error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
+	error InsufficientLiquidity();
 
 	event NewRewardsCycle(uint256 indexed cycleEnd, uint256 rewardsAmt);
 	event DepositedFromStaking(bytes32 indexed source, address indexed caller, uint256 baseAmt, uint256 rewardsAmt);
@@ -366,6 +367,12 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 		if ((assets = previewRedeem(shares)) == 0) {
 			revert ZeroAssets();
 		}
+
+		// Check liquidity before attempting withdrawal to avoid gas-related failures being misinterpreted
+		if (IWAVAX(address(asset)).balanceOf(address(this)) < assets) {
+			revert InsufficientLiquidity();
+		}
+
 		beforeWithdraw(assets, shares);
 		_burn(msg.sender, shares);
 

--- a/contracts/contract/tokens/TokenggAVAX.sol
+++ b/contracts/contract/tokens/TokenggAVAX.sol
@@ -35,6 +35,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	error InsufficientShares();
 	error WithdrawAmountTooLarge();
 	error WithdrawForStakingDisabled();
+	error CannotGrantDefaultAdminRole();
 	error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
 
 	event NewRewardsCycle(uint256 indexed cycleEnd, uint256 rewardsAmt);
@@ -396,6 +397,9 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @param role The role identifier
 	/// @param account The account to grant the role to
 	function grantRole(bytes32 role, address account) public onlyRole(DEFAULT_ADMIN_ROLE) {
+		if (role == DEFAULT_ADMIN_ROLE) {
+			revert CannotGrantDefaultAdminRole();
+		}
 		_grantRole(role, account);
 	}
 
@@ -443,12 +447,6 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 		_pendingAdmin = address(0);
 
 		emit AdminTransferCanceled(msg.sender, canceledPendingAdmin);
-	}
-
-	/// @notice Renounce admin role - only if there's a pending admin
-	function renounceAdmin() public onlyRole(DEFAULT_ADMIN_ROLE) {
-		require(_pendingAdmin != address(0), "Must have pending admin to renounce");
-		_revokeRole(DEFAULT_ADMIN_ROLE, msg.sender);
 	}
 
 	/// @notice Max assets an owner can deposit

--- a/contracts/contract/tokens/TokenggAVAX.sol
+++ b/contracts/contract/tokens/TokenggAVAX.sol
@@ -214,7 +214,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @notice Accepts AVAX deposit from a minipool. Expects the base amount and rewards earned from staking
 	/// @param baseAmt The amount of liquid staker AVAX used to create a minipool
 	/// @param rewardAmt The rewards amount (in AVAX) earned from staking
-	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt) public payable onlySpecificRegisteredContract("MinipoolManager", msg.sender) {
+	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt) external payable onlySpecificRegisteredContract("MinipoolManager", msg.sender) {
 		_depositFromStaking(baseAmt, rewardAmt, MINIPOOL_SOURCE);
 	}
 
@@ -222,13 +222,13 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @param baseAmt The base amount being returned from staking/delegation
 	/// @param rewardAmt The reward amount from yield activities
 	/// @param source The source of the additional yield (i.e. MEV)
-	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt, bytes32 source) public payable onlyRole(STAKER_ROLE) {
+	function depositFromStaking(uint256 baseAmt, uint256 rewardAmt, bytes32 source) external payable onlyRole(STAKER_ROLE) {
 		_depositFromStaking(baseAmt, rewardAmt, source);
 	}
 
 	/// @notice Allows anyone to deposit yield to the contract
 	/// @param source The source of the yield (i.e. MEV)
-	function depositYield(bytes32 source) public payable {
+	function depositYield(bytes32 source) external payable {
 		ProtocolDAO protocolDAO = ProtocolDAO(getContractAddress("ProtocolDAO"));
 		uint256 totalAmt = msg.value;
 		uint256 feeAmt = totalAmt.mulDivDown(protocolDAO.getFeeBips(), 10000);
@@ -275,8 +275,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 			revert WithdrawForStakingDisabled();
 		}
 
-		TokenggAVAX ggAVAX = TokenggAVAX(payable(getContractAddress("TokenggAVAX")));
-		if (assets > ggAVAX.amountAvailableForStaking()) {
+		if (assets > amountAvailableForStaking()) {
 			revert WithdrawAmountTooLarge();
 		}
 
@@ -360,7 +359,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @notice Grant a role to an account - only admin can grant
 	/// @param role The role identifier
 	/// @param account The account to grant the role to
-	function grantRole(bytes32 role, address account) public onlyRole(DEFAULT_ADMIN_ROLE) {
+	function grantRole(bytes32 role, address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
 		if (role == DEFAULT_ADMIN_ROLE) {
 			revert CannotGrantDefaultAdminRole();
 		}
@@ -370,7 +369,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	/// @notice Revoke a role from an account - only admin can revoke
 	/// @param role The role identifier
 	/// @param account The account to revoke the role from
-	function revokeRole(bytes32 role, address account) public onlyRole(DEFAULT_ADMIN_ROLE) {
+	function revokeRole(bytes32 role, address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
 		// Prevent admin from revoking their own admin role without a pending admin
 		if (role == DEFAULT_ADMIN_ROLE && account == msg.sender && _pendingAdmin == address(0)) {
 			revert("Cannot revoke admin role without pending admin");
@@ -380,7 +379,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 
 	/// @notice Initiate admin transfer to a new address
 	/// @param newAdmin The address to transfer admin rights to
-	function transferAdmin(address newAdmin) public onlyRole(DEFAULT_ADMIN_ROLE) {
+	function transferAdmin(address newAdmin) external onlyRole(DEFAULT_ADMIN_ROLE) {
 		require(newAdmin != address(0), "New admin cannot be zero address");
 		require(newAdmin != msg.sender, "Cannot transfer to self");
 
@@ -389,7 +388,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	}
 
 	/// @notice Accept admin transfer - only pending admin can call
-	function acceptAdmin() public {
+	function acceptAdmin() external {
 		require(_pendingAdmin != address(0), "No pending admin transfer");
 		require(msg.sender == _pendingAdmin, "Only pending admin can accept");
 
@@ -404,7 +403,7 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 	}
 
 	/// @notice Cancel pending admin transfer - only current admin can call
-	function cancelAdminTransfer() public onlyRole(DEFAULT_ADMIN_ROLE) {
+	function cancelAdminTransfer() external onlyRole(DEFAULT_ADMIN_ROLE) {
 		require(_pendingAdmin != address(0), "No pending admin transfer");
 
 		address canceledPendingAdmin = _pendingAdmin;
@@ -461,13 +460,13 @@ contract TokenggAVAX is Initializable, ERC4626Upgradeable, BaseUpgradeable {
 
 	/// @notice Get the current admin address
 	/// @return address The current admin address
-	function admin() public view returns (address) {
+	function admin() external view returns (address) {
 		return _getAdmin();
 	}
 
 	/// @notice Get the pending admin address
 	/// @return address The pending admin address (zero if none)
-	function pendingAdmin() public view returns (address) {
+	function pendingAdmin() external view returns (address) {
 		return _pendingAdmin;
 	}
 

--- a/contracts/contract/tokens/TokenpstAVAX.sol
+++ b/contracts/contract/tokens/TokenpstAVAX.sol
@@ -92,6 +92,8 @@ contract TokenpstAVAX is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeab
 		// Approve vault to spend WAVAX
 		IWAVAX(underlyingAsset).approve(address(vault), assets);
 
+		stripYield();
+
 		// Deposit WAVAX into vault and get shares
 		uint256 vaultShares = IERC4626(vault).deposit(assets, address(this));
 
@@ -106,6 +108,8 @@ contract TokenpstAVAX is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeab
 	function withdraw(uint256 assets) public nonReentrant whenNotPaused returns (uint256 vaultShares) {
 		if (assets == 0) revert ZeroAmount();
 		if (balanceOf(msg.sender) < assets) revert InsufficientBalance();
+
+		stripYield();
 
 		// Calculate how many vault shares this represents
 		vaultShares = IERC4626(vault).convertToShares(assets);
@@ -126,6 +130,7 @@ contract TokenpstAVAX is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeab
 		if (assets == 0) revert ZeroAmount();
 		if (balanceOf(msg.sender) < assets) revert InsufficientBalance();
 
+		stripYield();
 		vaultShares = IERC4626(vault).convertToShares(assets);
 
 		_burn(msg.sender, assets);
@@ -137,9 +142,10 @@ contract TokenpstAVAX is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeab
 	}
 
 	/// @notice Calculate how much excess vault shares the contract has, and send them to vault to increase it's yield
-	function stripYield() external nonReentrant whenNotPaused {
-		uint256 excessShares = getExcessShares();
-		if (excessShares == 0) revert NoYieldToStrip();
+	/// @return excessShares Amount of excess shares stripped, or 0 if no excess
+	function stripYield() public whenNotPaused returns (uint256 excessShares) {
+		excessShares = getExcessShares();
+		if (excessShares == 0) return 0;
 
 		// Call depositAdditionalYield on the vault to burn the shares and emit event
 		IYieldDonor(payable(vault)).donateYield(excessShares, "pstAVAX");

--- a/contracts/contract/tokens/TokenpstAVAX.sol
+++ b/contracts/contract/tokens/TokenpstAVAX.sol
@@ -168,6 +168,8 @@ contract TokenpstAVAX is ERC20Upgradeable, OwnableUpgradeable, PausableUpgradeab
 
 		if (ggAVAXTotalAssets <= totalPstTokens) return 0; // No excess if no yield
 
+		if (pstAVAXVaultShares * ggAVAXTotalAssets < totalPstTokens * ggAVAXTotalShares) return 0;
+
 		uint256 numerator = pstAVAXVaultShares * ggAVAXTotalAssets - totalPstTokens * ggAVAXTotalShares;
 		uint256 denominator = ggAVAXTotalAssets - totalPstTokens;
 

--- a/script/upgrade-liquid-staking-system.s.sol
+++ b/script/upgrade-liquid-staking-system.s.sol
@@ -67,7 +67,7 @@ contract UpgradeTokenggAVAX is Script, EnvironmentConfig {
 		TransparentUpgradeableProxy withdrawQueueProxy = new TransparentUpgradeableProxy(
 			address(withdrawQueueImpl),
 			address(withdrawQueueProxyAdmin),
-			abi.encodeWithSelector(withdrawQueueImpl.initialize.selector, getAddress("TokenggAVAX"), unstakeDelay, expirationDelay)
+			abi.encodeWithSelector(withdrawQueueImpl.initialize.selector, getAddress("TokenggAVAX"), getAddress("Storage"), unstakeDelay, expirationDelay)
 		);
 		console2.log("WithdrawQueue proxy deployed at", address(withdrawQueueProxy));
 		console2.log("Default admin (deployer):", deployer);

--- a/script/upgrade-liquid-staking-system.s.sol
+++ b/script/upgrade-liquid-staking-system.s.sol
@@ -78,10 +78,10 @@ contract UpgradeTokenggAVAX is Script, EnvironmentConfig {
 			withdrawQueue.grantRole(withdrawQueue.DEPOSITOR_ROLE(), address(depositor));
 			withdrawQueue.grantRole(withdrawQueue.DEFAULT_ADMIN_ROLE(), address(guardian));
 
-			// Configure maxPendingRequestsLimit
+			// Configure maxRequestsPerStakingDeposit
 			uint256 maxPendingRequests = vm.envUint("MAX_PENDING_REQUESTS_LIMIT");
-			withdrawQueue.setMaxPendingRequestsLimit(maxPendingRequests);
-			console2.log("MaxPendingRequestsLimit set to:", maxPendingRequests);
+			withdrawQueue.setMaxRequestsPerStakingDeposit(maxPendingRequests);
+			console2.log("MaxRequestsPerStakingDeposit set to:", maxPendingRequests);
 
 			withdrawQueue.renounceRole(withdrawQueue.DEFAULT_ADMIN_ROLE(), address(deployer));
 		}
@@ -248,7 +248,7 @@ contract UpgradeTokenggAVAX is Script, EnvironmentConfig {
 
 		// Verify max pending requests limit
 		uint256 expectedMaxPending = vm.envUint("MAX_PENDING_REQUESTS_LIMIT");
-		require(withdrawQueue.getMaxPendingRequestsLimit() == expectedMaxPending, "Max pending requests limit mismatch");
+		require(withdrawQueue.getMaxRequestsPerStakingDeposit() == expectedMaxPending, "Max requests per staking deposit mismatch");
 		console2.log("._/ WithdrawQueue max pending requests limit set correctly");
 
 		// Verify depositor role

--- a/test/invariant/WithdrawQueueHandler.sol
+++ b/test/invariant/WithdrawQueueHandler.sol
@@ -124,7 +124,7 @@ contract WithdrawQueueHandler {
 
 	/// @notice User claims their fulfilled unstake request
 	function claimUnstake(uint256 actorSeed, uint256 requestIdSeed) external useActor(actorSeed) countCall("claimUnstake") {
-		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(msg.sender);
+		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(msg.sender, 0, 0);
 		if (userRequests.length == 0) return;
 
 		uint256 requestId = userRequests[bound(requestIdSeed, 0, userRequests.length - 1)];
@@ -142,7 +142,7 @@ contract WithdrawQueueHandler {
 
 	/// @notice User cancels their pending or fulfilled request
 	function cancelRequest(uint256 actorSeed, uint256 requestIdSeed) external useActor(actorSeed) countCall("cancelRequest") {
-		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(msg.sender);
+		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(msg.sender, 0, 0);
 		if (userRequests.length == 0) return;
 
 		uint256 requestId = userRequests[bound(requestIdSeed, 0, userRequests.length - 1)];

--- a/test/invariant/WithdrawQueueInvariants.t.sol
+++ b/test/invariant/WithdrawQueueInvariants.t.sol
@@ -142,7 +142,7 @@ contract WithdrawQueueInvariants is BaseTest {
 		address[] memory users = handler.getUsers();
 		for (uint256 j = 0; j < users.length; j++) {
 			address user = users[j];
-			uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(user);
+			uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(user, 0, 0);
 			for (uint256 k = 0; k < userRequests.length; k++) {
 				WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(userRequests[k]);
 

--- a/test/invariant/WithdrawQueueInvariants.t.sol
+++ b/test/invariant/WithdrawQueueInvariants.t.sol
@@ -30,7 +30,7 @@ contract WithdrawQueueInvariants is BaseTest {
 		// Deploy WithdrawQueue
 		vm.startPrank(guardian);
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
 
 		TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), initData);
 		withdrawQueue = WithdrawQueue(payable(address(proxy)));
@@ -66,14 +66,14 @@ contract WithdrawQueueInvariants is BaseTest {
 	function invariant_totalSystemBalanceConservation() external view {
 		uint256 systemAssets = address(withdrawQueue).balance + ggAVAX.totalAssets();
 		uint256 systemObligations = withdrawQueue.totalAllocatedFunds() + _calculateTotalPendingExpectedAssets();
-		
+
 		if (systemAssets < systemObligations) {
 			console2.log("INVARIANT VIOLATION: Total System Balance Conservation");
 			console2.log("System Assets:", systemAssets);
 			console2.log("System Obligations:", systemObligations);
 			console2.log("Deficit:", systemObligations - systemAssets);
 		}
-		
+
 		assert(systemAssets >= systemObligations);
 	}
 
@@ -82,13 +82,13 @@ contract WithdrawQueueInvariants is BaseTest {
 	function invariant_allocatedFundsAccounting() external view {
 		uint256 totalAllocated = withdrawQueue.totalAllocatedFunds();
 		uint256 sumOfFulfilledAllocations = _calculateSumOfFulfilledAllocations();
-		
+
 		if (totalAllocated != sumOfFulfilledAllocations) {
 			console2.log("INVARIANT VIOLATION: Allocated Funds Accounting");
 			console2.log("Total Allocated:", totalAllocated);
 			console2.log("Sum of Fulfilled Allocations:", sumOfFulfilledAllocations);
 		}
-		
+
 		assert(totalAllocated == sumOfFulfilledAllocations);
 	}
 
@@ -97,13 +97,13 @@ contract WithdrawQueueInvariants is BaseTest {
 	function invariant_shareConservation() external view {
 		uint256 withdrawQueueShares = ggAVAX.balanceOf(address(withdrawQueue));
 		uint256 totalRequestShares = _calculateTotalRequestShares();
-		
+
 		if (withdrawQueueShares != totalRequestShares) {
 			console2.log("INVARIANT VIOLATION: Share Conservation");
 			console2.log("WithdrawQueue Shares:", withdrawQueueShares);
 			console2.log("Total Request Shares:", totalRequestShares);
 		}
-		
+
 		assert(withdrawQueueShares == totalRequestShares);
 	}
 
@@ -117,19 +117,19 @@ contract WithdrawQueueInvariants is BaseTest {
 			bool isFulfilled = withdrawQueue.isFulfilledRequest(i);
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(i);
 			bool exists = req.requester != address(0);
-			
+
 			if (isPending && isFulfilled) {
 				console2.log("INVARIANT VIOLATION: Request State Exclusivity - Request is both pending and fulfilled");
 				console2.log("Request ID:", i);
 			}
-			
+
 			if ((isPending || isFulfilled) && !exists) {
 				console2.log("INVARIANT VIOLATION: Request State Exclusivity - Request in set but doesn't exist");
 				console2.log("Request ID:", i);
 				console2.log("Is Pending:", isPending);
 				console2.log("Is Fulfilled:", isFulfilled);
 			}
-			
+
 			assert(!(isPending && isFulfilled));
 			assert(!(isPending && !exists));
 			assert(!(isFulfilled && !exists));
@@ -145,14 +145,14 @@ contract WithdrawQueueInvariants is BaseTest {
 			uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(user);
 			for (uint256 k = 0; k < userRequests.length; k++) {
 				WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(userRequests[k]);
-				
+
 				if (req.requester != user) {
 					console2.log("INVARIANT VIOLATION: Request Ownership Consistency");
 					console2.log("User:", user);
 					console2.log("Request ID:", userRequests[k]);
 					console2.log("Actual Requester:", req.requester);
 				}
-				
+
 				assert(req.requester == user);
 			}
 		}
@@ -164,12 +164,12 @@ contract WithdrawQueueInvariants is BaseTest {
 		uint256[] memory pendingRequests = withdrawQueue.getAllPendingRequests();
 		for (uint256 i = 0; i < pendingRequests.length; i++) {
 			bool isPending = withdrawQueue.isRequestPending(pendingRequests[i]);
-			
+
 			if (!isPending) {
 				console2.log("INVARIANT VIOLATION: Queue Ordering Consistency");
 				console2.log("Request ID in pending array but not in pending set:", pendingRequests[i]);
 			}
-			
+
 			assert(isPending);
 		}
 	}
@@ -182,21 +182,21 @@ contract WithdrawQueueInvariants is BaseTest {
 		for (uint256 i = 0; i < withdrawQueue.nextRequestId(); i++) {
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(i);
 			if (req.requester != address(0)) {
-				
+
 				if (req.requestTime > req.claimableTime) {
 					console2.log("INVARIANT VIOLATION: Time Progression - requestTime > claimableTime");
 					console2.log("Request ID:", i);
 					console2.log("Request Time:", req.requestTime);
 					console2.log("Claimable Time:", req.claimableTime);
 				}
-				
+
 				if (req.claimableTime > req.expirationTime) {
 					console2.log("INVARIANT VIOLATION: Time Progression - claimableTime > expirationTime");
 					console2.log("Request ID:", i);
 					console2.log("Claimable Time:", req.claimableTime);
 					console2.log("Expiration Time:", req.expirationTime);
 				}
-				
+
 				assert(req.requestTime <= req.claimableTime);
 				assert(req.claimableTime <= req.expirationTime);
 			}
@@ -208,25 +208,25 @@ contract WithdrawQueueInvariants is BaseTest {
 	function invariant_delayConsistency() external view {
 		uint48 unstakeDelay = withdrawQueue.unstakeDelay();
 		uint48 expirationDelay = withdrawQueue.expirationDelay();
-		
+
 		for (uint256 i = 0; i < withdrawQueue.nextRequestId(); i++) {
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(i);
 			if (req.requester != address(0)) {
-				
+
 				if (req.claimableTime != req.requestTime + unstakeDelay) {
 					console2.log("INVARIANT VIOLATION: Delay Consistency - claimableTime incorrect");
 					console2.log("Request ID:", i);
 					console2.log("Expected claimableTime:", req.requestTime + unstakeDelay);
 					console2.log("Actual claimableTime:", req.claimableTime);
 				}
-				
+
 				if (req.expirationTime != req.claimableTime + expirationDelay) {
 					console2.log("INVARIANT VIOLATION: Delay Consistency - expirationTime incorrect");
 					console2.log("Request ID:", i);
 					console2.log("Expected expirationTime:", req.claimableTime + expirationDelay);
 					console2.log("Actual expirationTime:", req.expirationTime);
 				}
-				
+
 				assert(req.claimableTime == req.requestTime + unstakeDelay);
 				assert(req.expirationTime == req.claimableTime + expirationDelay);
 			}
@@ -241,17 +241,17 @@ contract WithdrawQueueInvariants is BaseTest {
 		for (uint256 i = 0; i < withdrawQueue.nextRequestId(); i++) {
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(i);
 			if (req.requester != address(0)) {
-				
+
 				if (req.expectedAssets == 0) {
 					console2.log("INVARIANT VIOLATION: Expected Assets Validity - expectedAssets is zero");
 					console2.log("Request ID:", i);
 				}
-				
+
 				if (req.shares == 0) {
 					console2.log("INVARIANT VIOLATION: Expected Assets Validity - shares is zero");
 					console2.log("Request ID:", i);
 				}
-				
+
 				assert(req.expectedAssets > 0);
 				assert(req.shares > 0);
 			}
@@ -263,13 +263,13 @@ contract WithdrawQueueInvariants is BaseTest {
 	function invariant_noNegativeBalances() external view {
 		uint256 totalAllocated = withdrawQueue.totalAllocatedFunds();
 		uint256 contractBalance = address(withdrawQueue).balance;
-		
+
 		if (contractBalance < totalAllocated) {
 			console2.log("INVARIANT VIOLATION: No Negative Balances - insufficient balance");
 			console2.log("Contract Balance:", contractBalance);
 			console2.log("Total Allocated:", totalAllocated);
 		}
-		
+
 		assert(contractBalance >= totalAllocated);
 	}
 
@@ -281,13 +281,13 @@ contract WithdrawQueueInvariants is BaseTest {
 		uint256[] memory fulfilledRequests = withdrawQueue.getAllFulfilledRequests();
 		for (uint256 i = 0; i < fulfilledRequests.length; i++) {
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(fulfilledRequests[i]);
-			
+
 			if (req.allocatedFunds == 0) {
 				console2.log("INVARIANT VIOLATION: Fulfilled Request Completeness");
 				console2.log("Request ID:", fulfilledRequests[i]);
 				console2.log("Allocated Funds:", req.allocatedFunds);
 			}
-			
+
 			assert(req.allocatedFunds > 0);
 		}
 	}
@@ -299,7 +299,7 @@ contract WithdrawQueueInvariants is BaseTest {
 		for (uint256 i = 1; i < pendingRequests.length; i++) {
 			WithdrawQueue.UnstakeRequest memory prevReq = withdrawQueue.getRequestInfo(pendingRequests[i-1]);
 			WithdrawQueue.UnstakeRequest memory currReq = withdrawQueue.getRequestInfo(pendingRequests[i]);
-			
+
 			if (prevReq.requestTime > currReq.requestTime) {
 				console2.log("INVARIANT VIOLATION: FIFO Processing");
 				console2.log("Previous Request ID:", pendingRequests[i-1]);
@@ -307,7 +307,7 @@ contract WithdrawQueueInvariants is BaseTest {
 				console2.log("Current Request ID:", pendingRequests[i]);
 				console2.log("Current Request Time:", currReq.requestTime);
 			}
-			
+
 			assert(prevReq.requestTime <= currReq.requestTime);
 		}
 	}
@@ -336,12 +336,12 @@ contract WithdrawQueueInvariants is BaseTest {
 	function _calculateTotalRequestShares() internal view returns (uint256 total) {
 		uint256[] memory pendingRequests = withdrawQueue.getAllPendingRequests();
 		uint256[] memory fulfilledRequests = withdrawQueue.getAllFulfilledRequests();
-		
+
 		for (uint256 i = 0; i < pendingRequests.length; i++) {
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(pendingRequests[i]);
 			total += req.shares;
 		}
-		
+
 		for (uint256 i = 0; i < fulfilledRequests.length; i++) {
 			WithdrawQueue.UnstakeRequest memory req = withdrawQueue.getRequestInfo(fulfilledRequests[i]);
 			total += req.shares;

--- a/test/invariant/WithdrawQueueInvariants.t.sol
+++ b/test/invariant/WithdrawQueueInvariants.t.sol
@@ -41,8 +41,8 @@ contract WithdrawQueueInvariants is BaseTest {
 		ggAVAX.grantRole(ggAVAX.STAKER_ROLE(), charlie);
 		withdrawQueue.grantRole(withdrawQueue.DEPOSITOR_ROLE(), charlie);
 
-		// Set max pending requests limit for testing
-		withdrawQueue.setMaxPendingRequestsLimit(25);
+		// Set max requests per staking deposit for testing
+		withdrawQueue.setMaxRequestsPerStakingDeposit(25);
 
 		// Set reserve ratio to 0% so all funds can be withdrawn for staking
 		store.setUint(keccak256("ProtocolDAO.TargetGGAVAXReserveRate"), 0);

--- a/test/unit/ERC4626Std.t.sol
+++ b/test/unit/ERC4626Std.t.sol
@@ -31,7 +31,11 @@ contract ERC4626StdTest is ERC4626Test {
 		ggAVAX.syncRewards();
 
 		// Grant DEFAULT_ADMIN_ROLE to the test contract so it can grant roles during testing
-		ggAVAX.grantRole(ggAVAX.DEFAULT_ADMIN_ROLE(), address(this));
+		ggAVAX.transferAdmin(address(this));
+		vm.stopPrank();
+
+		ggAVAX.acceptAdmin();
+
 
 		_vault_ = address(ggAVAX);
 		_delta_ = 0;

--- a/test/unit/TokenggAVAX.t.sol
+++ b/test/unit/TokenggAVAX.t.sol
@@ -1282,4 +1282,45 @@ contract TokenggAVAXTest is BaseTest, IWithdrawer {
 		// depositor2 should get fewer shares than depositor1 got initially
 		assertLt(shares2, shares1);
 	}
+
+	function testCurrentErrorOnInsufficientLiquidity() public {
+		alice = getActorWithTokens("alice", 100 ether, 100 ether);
+
+		vm.startPrank(guardian);
+		ggAVAX.grantRole(ggAVAX.WITHDRAW_QUEUE_ROLE(), alice);
+		ggAVAX.grantRole(ggAVAX.STAKER_ROLE(), alice);
+		dao.setWithdrawForDelegationEnabled(true);
+		store.setUint(keccak256("ProtocolDAO.TargetGGAVAXReserveRate"), 0 ether);
+
+		vm.stopPrank();
+
+		// 1. Alice deposits AVAX to get ggAVAX shares
+		vm.startPrank(alice);
+		uint256 depositAmount = 50 ether;
+		ggAVAX.depositAVAX{value: depositAmount}();
+		uint256 shares = ggAVAX.balanceOf(alice);
+		vm.stopPrank();
+
+		// 2. Drain all WAVAX from the contract (simulating insufficient liquidity)
+		vm.startPrank(alice);
+		ggAVAX.withdrawForStaking(50 ether, bytes32("TEST_YIELD"));
+		vm.stopPrank();
+
+
+		// 3. Try to redeem - this should show us the current error
+		vm.startPrank(alice);
+		try ggAVAX.redeemAVAX(shares) {
+			revert("Should have failed");
+		} catch Error(string memory reason) {
+			console2.log("Error string:", reason);
+		} catch Panic(uint errorCode) {
+			console2.log("Panic code:", errorCode);
+		} catch (bytes memory lowLevelData) {
+			console2.log("Low level error data length:", lowLevelData.length);
+			if (lowLevelData.length > 0) {
+				console2.logBytes(lowLevelData);
+			}
+		}
+		vm.stopPrank();
+	}
 }

--- a/test/unit/TokenggAVAXAccessControl.t.sol
+++ b/test/unit/TokenggAVAXAccessControl.t.sol
@@ -314,44 +314,9 @@ contract TokenggAVAXAccessControlTest is BaseTest {
 	// Renounce Admin Tests
 	// =============================================================================
 
-	function testRenounceAdmin() public {
-		// Initiate transfer first
-		vm.prank(admin);
-		token.transferAdmin(newAdmin);
-
-		// Renounce admin
-		vm.prank(admin);
-		token.renounceAdmin();
-
-		// Admin should no longer have role
-		assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
-		assertEq(token.admin(), address(0));
-		assertEq(token.pendingAdmin(), newAdmin);
-	}
-
-	function testRenounceAdminRequiresPendingAdmin() public {
-		// Cannot renounce without pending admin
-		vm.expectRevert("Must have pending admin to renounce");
-
-		vm.prank(admin);
-		token.renounceAdmin();
-	}
-
-	function testRenounceAdminOnlyAdmin() public {
-		// Initiate transfer
-		vm.prank(admin);
-		token.transferAdmin(newAdmin);
-
-		// Only admin can renounce
-		vm.expectRevert(abi.encodeWithSelector(
-			TokenggAVAX.AccessControlUnauthorizedAccount.selector,
-			user1,
-			DEFAULT_ADMIN_ROLE
-		));
-
-		vm.prank(user1);
-		token.renounceAdmin();
-	}
+	// NOTE: renounceAdmin() tests removed as the function has been removed
+	// for security reasons (HYP-2 audit fix). The function was dangerous as it
+	// could create zero admin scenarios.
 
 	// =============================================================================
 	// Role Access Control Tests
@@ -481,6 +446,200 @@ contract TokenggAVAXAccessControlTest is BaseTest {
 		vm.prank(newAdmin);
 		token.acceptAdmin();
 		assertEq(token.admin(), newAdmin);
+	}
+
+	// =============================================================================
+	// HYP-2 Audit Fix Tests
+	// =============================================================================
+
+	function testCannotGrantDefaultAdminRole() public {
+		// This test verifies the fix for HYP-2 issue #1:
+		// grantRole() now reverts when attempting to grant DEFAULT_ADMIN_ROLE
+
+		// Initial state: admin is the default admin
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertEq(token.admin(), admin);
+
+		// Create a new admin candidate
+		address candidateAdmin = getActor("candidateAdmin");
+
+		// Attempting to grant DEFAULT_ADMIN_ROLE should now revert
+		vm.startPrank(admin);
+		vm.expectRevert(TokenggAVAX.CannotGrantDefaultAdminRole.selector);
+		token.grantRole(DEFAULT_ADMIN_ROLE, candidateAdmin);
+		vm.stopPrank();
+
+		// Verify state unchanged - only admin has admin role
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, candidateAdmin));
+
+		// Admin should still be able to grant other roles
+		vm.startPrank(admin);
+		token.grantRole(STAKER_ROLE, user1);
+		vm.stopPrank();
+		assertTrue(token.hasRole(STAKER_ROLE, user1));
+	}
+
+	function testRenounceAdminFunctionRemoved() public {
+		// This test verifies the fix for HYP-2 issue #2:
+		// renounceAdmin() function has been removed to prevent zero admin scenarios
+		
+		// Initial state: admin is the default admin
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertEq(token.admin(), admin);
+		assertEq(token.pendingAdmin(), address(0));
+
+		// Create a new admin candidate
+		address candidateAdmin = getActor("candidateAdmin");
+
+		// Step 1: Current admin initiates transfer to new admin
+		vm.startPrank(admin);
+		token.transferAdmin(candidateAdmin);
+		vm.stopPrank();
+
+		// Verify transfer is pending
+		assertEq(token.pendingAdmin(), candidateAdmin);
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, candidateAdmin));
+
+		// Step 2: The fix prevents zero admin scenarios because:
+		// - renounceAdmin() function no longer exists (would cause compilation error if called)
+		// - Current admin retains admin role until new admin accepts
+		// - Admin can cancel transfer if needed
+		
+		// Uncommenting the line below would cause a compilation error:
+		// token.renounceAdmin(); // <- This function no longer exists!
+		
+		// Admin still has admin role during pending transfer (no zero admin state possible)
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertEq(token.admin(), admin); // Admin still the admin
+		
+		// Admin can still perform admin functions during pending transfer
+		vm.startPrank(admin);
+		token.grantRole(STAKER_ROLE, user1);
+		vm.stopPrank();
+		assertTrue(token.hasRole(STAKER_ROLE, user1));
+
+		// Step 3: Admin can cancel transfer if needed (safe alternative to renounce)
+		vm.startPrank(admin);
+		token.cancelAdminTransfer();
+		vm.stopPrank();
+		
+		// Verify transfer was canceled - still have admin, no zero admin state
+		assertEq(token.pendingAdmin(), address(0));
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertEq(token.admin(), admin);
+
+		// Step 4: Demonstrate proper admin transfer flow (safe, atomic)
+		vm.startPrank(admin);
+		token.transferAdmin(candidateAdmin);
+		vm.stopPrank();
+
+		// Admin retains admin role until new admin accepts (no gap)
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, candidateAdmin));
+		assertEq(token.admin(), admin);
+		assertEq(token.pendingAdmin(), candidateAdmin);
+
+		// New admin accepts transfer - atomic role transfer occurs
+		vm.startPrank(candidateAdmin);
+		token.acceptAdmin();
+		vm.stopPrank();
+
+		// Verify proper atomic transfer - old admin revoked, new admin granted, no gap
+		assertFalse(token.hasRole(DEFAULT_ADMIN_ROLE, admin));
+		assertTrue(token.hasRole(DEFAULT_ADMIN_ROLE, candidateAdmin));
+		assertEq(token.admin(), candidateAdmin);
+		assertEq(token.pendingAdmin(), address(0));
+
+		// New admin can perform admin functions
+		vm.startPrank(candidateAdmin);
+		token.grantRole(STAKER_ROLE, user2);
+		vm.stopPrank();
+		assertTrue(token.hasRole(STAKER_ROLE, user2));
+	}
+
+	function testTransferAdminToSelfReverts() public {
+		// Should not be able to transfer admin to yourself
+		vm.startPrank(admin);
+		vm.expectRevert("Cannot transfer to self");
+		token.transferAdmin(admin);
+		vm.stopPrank();
+	}
+
+	function testTransferAdminToZeroAddressReverts() public {
+		// Should not be able to transfer admin to zero address
+		vm.startPrank(admin);
+		vm.expectRevert("New admin cannot be zero address");
+		token.transferAdmin(address(0));
+		vm.stopPrank();
+	}
+
+	function testMultipleTransferAdminOverwritesPending() public {
+		// Multiple transfers should overwrite the pending admin
+		address firstCandidate = getActor("firstCandidate");
+		address secondCandidate = getActor("secondCandidate");
+		
+		vm.startPrank(admin);
+		token.transferAdmin(firstCandidate);
+		assertEq(token.pendingAdmin(), firstCandidate);
+		
+		// Transfer to second candidate should overwrite
+		token.transferAdmin(secondCandidate);
+		assertEq(token.pendingAdmin(), secondCandidate);
+		vm.stopPrank();
+		
+		// First candidate can't accept anymore
+		vm.startPrank(firstCandidate);
+		vm.expectRevert("Only pending admin can accept");
+		token.acceptAdmin();
+		vm.stopPrank();
+		
+		// Second candidate can accept
+		vm.startPrank(secondCandidate);
+		token.acceptAdmin();
+		vm.stopPrank();
+		
+		assertEq(token.admin(), secondCandidate);
+	}
+
+	function testAdminTransferEventsEmitted() public {
+		// Test that proper events are emitted during admin transfer process
+		address newAdminCandidate = getActor("newAdminCandidate");
+		
+		// Test AdminTransferInitiated event
+		vm.expectEmit(true, true, true, true);
+		emit AdminTransferInitiated(admin, newAdminCandidate);
+		
+		vm.startPrank(admin);
+		token.transferAdmin(newAdminCandidate);
+		vm.stopPrank();
+		
+		// Test AdminTransferCompleted event and role events
+		vm.expectEmit(true, true, true, true);
+		emit RoleRevoked(DEFAULT_ADMIN_ROLE, admin, newAdminCandidate);
+		vm.expectEmit(true, true, true, true);
+		emit RoleGranted(DEFAULT_ADMIN_ROLE, newAdminCandidate, newAdminCandidate);
+		vm.expectEmit(true, true, true, true);
+		emit AdminTransferCompleted(admin, newAdminCandidate);
+		
+		vm.startPrank(newAdminCandidate);
+		token.acceptAdmin();
+		vm.stopPrank();
+	}
+
+	function testAdminTransferCancelEmitsEvent() public {
+		address newAdminCandidate = getActor("newAdminCandidate");
+		
+		vm.startPrank(admin);
+		token.transferAdmin(newAdminCandidate);
+		
+		// Test AdminTransferCanceled event
+		vm.expectEmit(true, true, true, true);
+		emit AdminTransferCanceled(admin, newAdminCandidate);
+		
+		token.cancelAdminTransfer();
+		vm.stopPrank();
 	}
 
 	// =============================================================================

--- a/test/unit/TokenpstAVAXTest.t.sol
+++ b/test/unit/TokenpstAVAXTest.t.sol
@@ -4,23 +4,33 @@ pragma solidity 0.8.17;
 import "./utils/BaseTest.sol";
 import {TokenpstAVAX} from "../../contracts/contract/tokens/TokenpstAVAX.sol";
 import {WithdrawQueue} from "../../contracts/contract/WithdrawQueue.sol";
+import {console2} from "forge-std/console2.sol";
+import {FixedPointMathLib} from "@rari-capital/solmate/src/utils/FixedPointMathLib.sol";
 
 contract TokenpstAVAXTest is BaseTest {
+	using FixedPointMathLib for uint256;
+
 	TokenpstAVAX pstAVAX;
 	WithdrawQueue withdrawQueue;
 	address alice;
 	address bob;
+	address cam;
 
 	function setUp() public override {
 		super.setUp();
 
 		alice = getActorWithTokens("alice", MAX_AMT, MAX_AMT);
 		bob = getActorWithTokens("bob", MAX_AMT, MAX_AMT);
+		cam = getActorWithTokens("cam", MAX_AMT, MAX_AMT);
 
 		// Deploy WithdrawQueue
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
 		bytes memory withdrawQueueInitData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), 7 days, 14 days);
-		TransparentUpgradeableProxy withdrawQueueProxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), withdrawQueueInitData);
+		TransparentUpgradeableProxy withdrawQueueProxy = new TransparentUpgradeableProxy(
+			address(withdrawQueueImpl),
+			address(proxyAdmin),
+			withdrawQueueInitData
+		);
 		withdrawQueue = WithdrawQueue(payable(address(withdrawQueueProxy)));
 
 		// Deploy
@@ -84,7 +94,6 @@ contract TokenpstAVAXTest is BaseTest {
 		ggAVAX.syncRewards();
 		skip(ggAVAX.rewardsCycleLength());
 
-
 		assertEq(ggAVAX.convertToAssets(ggAVAX.balanceOf(bob)), 1000 ether + 500 ether);
 		assertEq(ggAVAX.convertToAssets(ggAVAX.balanceOf(address(pstAVAX))), 1000 ether + 500 ether);
 
@@ -110,7 +119,12 @@ contract TokenpstAVAXTest is BaseTest {
 		assertEq(assetsLeft, 0);
 	}
 
-	function testStripYield() public {
+	function testStripYieldDefault() public {
+		// we have to create a ggAVAX holder I think
+		uint256 ggAVAXDeposit = 1 ether;
+		vm.prank(bob);
+		ggAVAX.depositAVAX{value: ggAVAXDeposit}();
+
 		uint256 assets = 1 ether;
 		vm.prank(alice);
 		pstAVAX.depositAVAX{value: assets}();
@@ -129,15 +143,14 @@ contract TokenpstAVAXTest is BaseTest {
 
 		vm.stopPrank();
 
-		uint256 pstAVAXInggAVAX = ggAVAX.convertToShares(assets);
-		assertEq(pstAVAX.getExcessShares(), rewardsAmt);
+		assertEq(pstAVAX.getExcessShares(), rewardsAmt / 2);
 
 		vm.prank(alice);
 		pstAVAX.withdraw(assets);
 		assertEq(pstAVAX.balanceOf(alice), 0);
 		assertEq(pstAVAX.totalSupply(), 0);
-		assertEq(ggAVAX.balanceOf(address(pstAVAX)), pstAVAXInggAVAX);
-		assertEq(ggAVAX.balanceOf(alice), pstAVAXInggAVAX);
+		assertEq(ggAVAX.balanceOf(address(pstAVAX)), 0);
+		assertLt(ggAVAX.balanceOf(alice), 1 ether);
 
 		pstAVAX.stripYield();
 		assertEq(pstAVAX.getExcessShares(), 0);
@@ -322,8 +335,8 @@ contract TokenpstAVAXTest is BaseTest {
 	}
 
 	function testStripYieldNoYield() public {
-		vm.expectRevert(TokenpstAVAX.NoYieldToStrip.selector);
-		pstAVAX.stripYield();
+		uint256 excessShares = pstAVAX.stripYield();
+		assertEq(excessShares, 0);
 	}
 
 	function testDepositEvent() public {
@@ -456,6 +469,217 @@ contract TokenpstAVAXTest is BaseTest {
 		assertEq(pstAVAX.totalSupply(), 0);
 		assertEq(pstAVAX.balanceOf(alice), 0);
 		assertEq(pstAVAX.balanceOf(bob), 0);
+	}
+
+	function testNoggAVAXHoldersBeforeRewards() public {
+		assertEq(pstAVAX.totalSupply(), 0);
+		assertEq(ggAVAX.balanceOf(address(pstAVAX)), 0);
+		assertEq(ggAVAX.totalSupply(), 0);
+		assertEq(ggAVAX.totalAssets(), 0);
+
+		uint256 assets = 10 ether;
+		vm.prank(alice);
+		pstAVAX.depositAVAX{value: assets}();
+
+		assertEq(pstAVAX.balanceOf(alice), assets);
+		assertEq(pstAVAX.totalSupply(), assets);
+		assertEq(ggAVAX.balanceOf(address(pstAVAX)), assets);
+
+		// vm.startPrank(cam);
+		// ggAVAX.depositAVAX{value: assets}();
+		// vm.stopPrank();
+
+		// Deposit some rewards to ggAVAX
+		vm.startPrank(bob);
+		uint256 rewardsAmt = 10 ether;
+		wavax.deposit{value: rewardsAmt}();
+		wavax.transfer(address(ggAVAX), rewardsAmt);
+		vm.stopPrank();
+
+		// Warp and sync rewards
+		vm.warp(ggAVAX.rewardsCycleEnd());
+		ggAVAX.syncRewards();
+		vm.warp(ggAVAX.rewardsCycleEnd());
+
+		assertEq(ggAVAX.totalAssets(), assets + rewardsAmt);
+		assertEq(ggAVAX.totalSupply(), assets);
+		assertEq(ggAVAX.convertToShares(1 ether), 0.5 ether);
+
+		// Because there are no other ggAVAX share holders, pstAVAX assumes it can strip
+		// all yield. This is a known issue when there are no ggAVAX holders
+		uint256 sharesStripped = pstAVAX.stripYield();
+		assertEq(sharesStripped, assets);
+
+		// Because all yield was stripped, this call will revert attempting to send
+		// alice an appropraite number of ggAVAX shares
+		vm.startPrank(alice);
+		vm.expectRevert();
+		uint256 sharesWithdrawn = pstAVAX.withdraw(assets);
+		vm.stopPrank();
+	}
+
+	function testOneggAVAXHolderBeforeRewards() public {
+		assertEq(pstAVAX.totalSupply(), 0);
+		assertEq(ggAVAX.balanceOf(address(pstAVAX)), 0);
+		assertEq(ggAVAX.totalSupply(), 0);
+		assertEq(ggAVAX.totalAssets(), 0);
+
+		uint256 pstAVAXDeposit = 10 ether;
+		vm.prank(alice);
+		pstAVAX.depositAVAX{value: pstAVAXDeposit}();
+
+		assertEq(pstAVAX.balanceOf(alice), pstAVAXDeposit);
+		assertEq(pstAVAX.totalSupply(), pstAVAXDeposit);
+		assertEq(ggAVAX.balanceOf(address(pstAVAX)), pstAVAXDeposit);
+
+		vm.startPrank(cam);
+		ggAVAX.depositAVAX{value: pstAVAXDeposit}();
+		vm.stopPrank();
+
+		// Deposit some rewards to ggAVAX
+		vm.startPrank(bob);
+		uint256 rewardsAmt = 10 ether;
+		wavax.deposit{value: rewardsAmt}();
+		wavax.transfer(address(ggAVAX), rewardsAmt);
+		vm.stopPrank();
+
+		// Warp and sync rewards
+		vm.warp(ggAVAX.rewardsCycleEnd());
+		ggAVAX.syncRewards();
+		vm.warp(ggAVAX.rewardsCycleEnd());
+
+		assertEq(ggAVAX.totalAssets(), pstAVAXDeposit + rewardsAmt + pstAVAXDeposit);
+		assertEq(ggAVAX.totalSupply(), pstAVAXDeposit + pstAVAXDeposit);
+		assertEq(ggAVAX.convertToShares(1 ether), ggAVAX.totalSupply().divWadDown(ggAVAX.totalAssets()));
+
+		// Now there is another holder of ggAVAX, so the stippedShares will
+		// not be the full amount of ggAVAX holding in pstAVAX
+		uint256 sharesStripped = pstAVAX.stripYield();
+		assertEq(sharesStripped, rewardsAmt / 2);
+
+		// Alice gets enough ggAVAX back to cover her initial pstAVAX deposit
+		vm.prank(alice);
+		uint256 sharesWithdrawn = pstAVAX.withdraw(pstAVAXDeposit);
+		assertEq(sharesWithdrawn, rewardsAmt / 2);
+		assertEq(ggAVAX.convertToAssets(sharesWithdrawn), pstAVAXDeposit);
+	}
+
+	function testWithdrawalAffectsonExcessShares() public {
+		// Test setup
+		uint256 pstDeposit = 1000 ether;
+		uint256 ggDeposit = 1000 ether;
+		uint256 donation = 100 ether;
+
+		address pstDepositor1 = makeAddr("pstDepositor1");
+		vm.deal(pstDepositor1, 10 * ggDeposit);
+
+		address pstDepositor2 = makeAddr("pstDepositor2");
+		vm.deal(pstDepositor2, 10 * ggDeposit);
+
+		address pstDepositor3 = makeAddr("pstDepositor3");
+		vm.deal(pstDepositor3, 10 * ggDeposit);
+
+		address donater = makeAddr("donater");
+		vm.deal(donater, 10 * ggDeposit);
+
+		address ggDepositor1 = makeAddr("ggDepositor1");
+		vm.deal(ggDepositor1, 10 * ggDeposit);
+
+		address ggDepositor2 = makeAddr("ggDepositor2");
+		vm.deal(ggDepositor2, 10 * ggDeposit);
+
+		assertEq(pstAVAX.totalSupply(), 0);
+		assertEq(ggAVAX.balanceOf(address(pstAVAX)), 0);
+		assertEq(ggAVAX.totalSupply(), 0);
+		assertEq(ggAVAX.totalAssets(), 0);
+
+		vm.prank(pstDepositor1);
+		pstAVAX.depositAVAX{value: pstDeposit}();
+		assertEq(pstAVAX.balanceOf(pstDepositor1), pstDeposit);
+
+		// Deposit avax into ggAVAX
+		vm.prank(ggDepositor1);
+		uint256 ggDepositor1Shares = ggAVAX.depositAVAX{value: ggDeposit}();
+
+		assertEq(ggDepositor1Shares, ggDeposit);
+		assertEq(ggAVAX.totalSupply(), ggDeposit + pstDeposit);
+
+		// Donate some amout of rewards to ggAVAX
+		vm.startPrank(donater);
+		wavax.deposit{value: donation}();
+		wavax.transfer(address(ggAVAX), donation);
+		vm.stopPrank();
+
+		// Warp and sync rewards
+		vm.warp(ggAVAX.rewardsCycleEnd());
+		ggAVAX.syncRewards();
+		vm.warp(ggAVAX.rewardsCycleEnd());
+
+		assertEq(ggAVAX.totalAssets(), ggDeposit + pstDeposit + donation);
+		assertEq(ggAVAX.previewRedeem(1 ether), ggAVAX.totalAssets().divWadDown(ggAVAX.totalSupply()));
+
+		uint256 expectedExcessShares = 90909090909090909090;
+		assertGt(pstAVAX.getExcessShares(), 0);
+		assertEq(pstAVAX.getExcessShares(), expectedExcessShares);
+
+		vm.prank(pstDepositor1);
+		uint256 ggAVAXsharesWithdrawnDepositor1 = pstAVAX.withdraw(pstDeposit);
+
+		assertApproxEqAbs(ggAVAX.convertToAssets(ggAVAXsharesWithdrawnDepositor1), pstDeposit, 1);
+		assertApproxEqAbs(pstAVAX.getExcessShares(), 0, 1);
+		assertApproxEqAbs(pstAVAX.totalSupply(), 0, 1);
+		assertApproxEqAbs(ggAVAX.balanceOf(address(pstAVAX)), 0, 1);
+		assertEq(ggAVAX.totalSupply(), ggDeposit + pstDeposit - expectedExcessShares);
+
+		uint256 sharesStripped = pstAVAX.stripYield();
+		assertApproxEqAbs(sharesStripped, 0, 1);
+
+		vm.prank(pstDepositor2);
+		pstAVAX.depositAVAX{value: pstDeposit}();
+
+		assertEq(pstAVAX.balanceOf(pstDepositor2), pstDeposit);
+		assertEq(pstAVAX.totalSupply(), pstDeposit);
+	}
+
+	function testStripYieldGasMeasurement() public {
+		// Setup scenario with yield to be stripped
+		uint256 assets = 1000 ether;
+
+		// Alice deposits into pstAVAX
+		vm.prank(alice);
+		pstAVAX.depositAVAX{value: assets}();
+
+		// Bob deposits directly into ggAVAX (creates another holder)
+		vm.prank(bob);
+		ggAVAX.depositAVAX{value: assets}();
+
+		// Skip time to allow for rewards
+		skip(ggAVAX.rewardsCycleLength());
+
+		// Add rewards to ggAVAX (simulate yield generation)
+		vm.deal(address(ggAVAX), 1000 ether);
+		vm.prank(address(ggAVAX));
+		wavax.deposit{value: 1000 ether}();
+
+		ggAVAX.syncRewards();
+		skip(ggAVAX.rewardsCycleLength());
+
+		// Verify there are excess shares to strip
+		uint256 excessShares = pstAVAX.getExcessShares();
+		assertGt(excessShares, 0);
+
+		// Measure gas for stripYield call
+		uint256 gasBefore = gasleft();
+		uint256 sharesStripped = pstAVAX.stripYield();
+		uint256 gasUsed = gasBefore - gasleft();
+
+		// Log gas usage for visibility
+		// console2.log("Gas used for stripYield():", gasUsed);
+		// console2.log("Shares stripped:", sharesStripped);
+
+		// Verify the function worked
+		assertEq(sharesStripped, excessShares);
+		assertGt(sharesStripped, 0);
 	}
 
 	// Define events for testing (these match the contract events)

--- a/test/unit/TokenpstAVAXTest.t.sol
+++ b/test/unit/TokenpstAVAXTest.t.sol
@@ -19,7 +19,7 @@ contract TokenpstAVAXTest is BaseTest {
 
 		// Deploy WithdrawQueue
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory withdrawQueueInitData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), 7 days, 14 days);
+		bytes memory withdrawQueueInitData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), 7 days, 14 days);
 		TransparentUpgradeableProxy withdrawQueueProxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), withdrawQueueInitData);
 		withdrawQueue = WithdrawQueue(payable(address(withdrawQueueProxy)));
 

--- a/test/unit/WithdrawQueue.t.sol
+++ b/test/unit/WithdrawQueue.t.sol
@@ -1981,6 +1981,35 @@ contract WithdrawQueueTest is BaseTest {
 
 		console2.log("WithdrawQueue.depositFromStaking (fulfilling remaining 5 requests) gas:", gasUsed2);
 	}
+
+	function testFixBoundsChecking() public {
+		// Test that the HYP-3 fix properly handles cases where proRated amounts
+		// exceed the provided baseAmt/rewardAmt parameters
+
+		// Setup: Create unstake request and reduce ggAVAX liquidity
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 20 ether}();
+
+		uint256 unstakeAmount = 20 ether;
+		vm.startPrank(alice);
+		ggAVAX.approve(address(withdrawQueue), unstakeAmount);
+		uint256 requestId = withdrawQueue.requestUnstake(unstakeAmount);
+		vm.stopPrank();
+
+		// Give contract existing balance and reduce ggAVAX liquidity
+		vm.deal(address(withdrawQueue), 15 ether);
+		vm.prank(address(minipoolMgr));
+		ggAVAX.withdrawForStaking(20 ether);
+
+		// Call with small amounts that would have caused OutOfFunds before fix
+		uint256 baseAmt = 2 ether;
+		uint256 rewardAmt = 1 ether;
+
+		// This should succeed (would have failed with OutOfFunds before fix)
+		vm.deal(charlie, baseAmt + rewardAmt);
+		vm.prank(charlie);
+		withdrawQueue.depositFromStaking{value: 3 ether}(baseAmt, rewardAmt, bytes32("HYP3_FIX_TEST"));
+	}
 }
 
 // Malicious contract that attempts reentrancy

--- a/test/unit/WithdrawQueue.t.sol
+++ b/test/unit/WithdrawQueue.t.sol
@@ -2324,6 +2324,76 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(request.requester, alice);
 		assertEq(request.shares, exactMinAmount);
 	}
+
+	function testDepositFromStakingEarlyReturnDonatesExcessFunds() public {
+		// Test that excess AVAX is properly donated back even when depositFromStaking hits early returns
+		// This verifies the fix for the bug where accumulated excessAVAX was lost on early returns
+
+		// Setup: Create initial liquidity and improve exchange rate
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 2000 ether}();
+
+		// Create first request that will be fulfilled with excess due to improved exchange rate
+		vm.prank(alice);
+		ggAVAX.approve(address(withdrawQueue), 100 ether);
+		vm.prank(alice);
+		uint256 requestId1 = withdrawQueue.requestUnstake(100 ether);
+
+		// Improve exchange rate by adding rewards
+		vm.prank(address(minipoolMgr));
+		ggAVAX.withdrawForStaking(500 ether);
+
+		vm.deal(address(minipoolMgr), 600 ether);
+
+		vm.prank(address(minipoolMgr));
+		ggAVAX.depositFromStaking{value: 600 ether}(500 ether, 100 ether);
+
+		// Advance time and sync rewards to improve exchange rate
+		vm.warp(block.timestamp + 15 days);
+		ggAVAX.syncRewards();
+		vm.warp(block.timestamp + 15 days);
+
+		// Create second large request that will trigger insufficient liquidity
+		vm.prank(alice);
+		ggAVAX.approve(address(withdrawQueue), 1500 ether);
+		vm.prank(alice);
+		uint256 requestId2 = withdrawQueue.requestUnstake(1500 ether);
+
+		// Reduce ggAVAX liquidity to force early return on second request
+		vm.startPrank(address(minipoolMgr));
+		uint256 currentLiquidity = ggAVAX.amountAvailableForStaking();
+		uint256 liquidityToWithdraw = currentLiquidity - 120 ether; // Leave enough for first request only
+		if (liquidityToWithdraw > 0) {
+			ggAVAX.withdrawForStaking(liquidityToWithdraw);
+		}
+		vm.stopPrank();
+
+		// Verify test setup
+		assertEq(withdrawQueue.getRequestInfo(requestId1).expectedAssets, 100 ether, "First request should expect 100 ether");
+		assertEq(withdrawQueue.getRequestInfo(requestId2).expectedAssets, 1575 ether, "Second request should expect 1575 ether");
+		assertEq(ggAVAX.amountAvailableForStaking(), 120 ether, "Should have 120 ether liquidity remaining");
+
+		// Execute depositFromStaking - should fulfill first request and hit early return on second
+		uint256 depositAmount = 200 ether;
+		vm.deal(charlie, depositAmount);
+		vm.prank(charlie);
+		withdrawQueue.depositFromStaking{value: depositAmount}(0, depositAmount, bytes32("TEST_YIELD"));
+
+		// Verify the scenario worked as expected
+		assertTrue(withdrawQueue.isFulfilledRequest(requestId1), "First request should be fulfilled");
+		assertTrue(withdrawQueue.isRequestPending(requestId2), "Second request should still be pending");
+
+		// Verify excess AVAX was properly donated back
+		// From the trace we can see:
+		// 1. redeemAVAX returned 105 ether (as shown in the Withdraw event)
+		// 2. Only 100 ether was allocated to the request (expectedAssets)
+		// 3. depositYield was called with 5 ether excess before the early return
+		// 4. The first request was allocated exactly 100 ether
+
+		assertGt(ggAVAX.asset().balanceOf(address(ggAVAX)), ggAVAX.amountAvailableForStaking());
+		// Key verification: The first request should be allocated exactly 100 ether despite 105 ether being redeemed
+		assertEq(withdrawQueue.getRequestInfo(requestId1).allocatedFunds, 100 ether, "First request should have exactly 100 ether allocated");
+	}
 }
 
 // Malicious contract that attempts reentrancy

--- a/test/unit/WithdrawQueue.t.sol
+++ b/test/unit/WithdrawQueue.t.sol
@@ -46,8 +46,8 @@ contract WithdrawQueueTest is BaseTest {
 		ggAVAX.grantRole(ggAVAX.STAKER_ROLE(), charlie);
 		withdrawQueue.grantRole(withdrawQueue.DEPOSITOR_ROLE(), charlie);
 
-		// Set max pending requests limit for testing
-		withdrawQueue.setMaxPendingRequestsLimit(25);
+		// Set max requests per staking deposit for testing
+		withdrawQueue.setMaxRequestsPerStakingDeposit(25);
 
 		// Set reserve ratio to 0% so all funds can be withdrawn for staking
 		vm.startPrank(guardian);
@@ -61,22 +61,22 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(withdrawQueue.unstakeDelay(), UNSTAKE_DELAY);
 		assertEq(withdrawQueue.expirationDelay(), EXPIRATION_DELAY);
 		assertEq(withdrawQueue.nextRequestId(), 0);
-		assertEq(withdrawQueue.getMaxPendingRequestsLimit(), 25);
+		assertEq(withdrawQueue.getMaxRequestsPerStakingDeposit(), 25);
 	}
 
-	function testMaxPendingRequestsLimit() public {
+	function testMaxRequestsPerStakingDeposit() public {
 		// Test getter
-		assertEq(withdrawQueue.getMaxPendingRequestsLimit(), 25);
+		assertEq(withdrawQueue.getMaxRequestsPerStakingDeposit(), 25);
 
 		// Test setter (only admin can set)
 		vm.prank(guardian);
-		withdrawQueue.setMaxPendingRequestsLimit(100);
-		assertEq(withdrawQueue.getMaxPendingRequestsLimit(), 100);
+		withdrawQueue.setMaxRequestsPerStakingDeposit(100);
+		assertEq(withdrawQueue.getMaxRequestsPerStakingDeposit(), 100);
 
 		// Test that non-admin cannot set
 		vm.prank(alice);
 		vm.expectRevert();
-		withdrawQueue.setMaxPendingRequestsLimit(200);
+		withdrawQueue.setMaxRequestsPerStakingDeposit(200);
 	}
 
 	function testSetUnstakeDelay() public {
@@ -1882,7 +1882,7 @@ contract WithdrawQueueTest is BaseTest {
 	function testConfigurableRequestsLimit() public {
 		// Test that changing the limit affects batching behavior
 		vm.prank(guardian);
-		withdrawQueue.setMaxPendingRequestsLimit(10); // Set lower limit
+		withdrawQueue.setMaxRequestsPerStakingDeposit(10); // Set lower limit
 
 		// Create 15 unstake requests (more than the 10 limit)
 		vm.startPrank(alice);

--- a/test/unit/WithdrawQueue.t.sol
+++ b/test/unit/WithdrawQueue.t.sol
@@ -34,7 +34,7 @@ contract WithdrawQueueTest is BaseTest {
 		// Deploy WithdrawQueue
 		vm.startPrank(guardian);
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
 
 		TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), initData);
 
@@ -114,7 +114,7 @@ contract WithdrawQueueTest is BaseTest {
 	function testInitializationEvent() public {
 		// Deploy a new WithdrawQueue to test the initialization event
 		WithdrawQueue newWithdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
 
 		// Expect the ContractInitialized event
 		vm.expectEmit(true, false, false, true);
@@ -1843,7 +1843,7 @@ contract WithdrawQueueTest is BaseTest {
 		// Deploy a new WithdrawQueue with the malicious ggAVAX
 		WithdrawQueue maliciousQueue;
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(maliciousGGAVAX), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(maliciousGGAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
 
 		TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), initData);
 
@@ -2010,6 +2010,63 @@ contract WithdrawQueueTest is BaseTest {
 		vm.prank(charlie);
 		withdrawQueue.depositFromStaking{value: 3 ether}(baseAmt, rewardAmt, bytes32("HYP3_FIX_TEST"));
 	}
+
+		function testDepositFromStakingWithFeeCalculation() public {
+		// Test that the fee calculation correctly ensures sufficient funds are deposited to TokenggAVAX
+
+		// Set a protocol fee for rewards (5% = 500 basis points)
+		vm.prank(guardian);
+		dao.setFeeBips(500); // 5% fee on rewards
+
+		// Setup: Create unstake request for 20 ether
+		vm.deal(alice, 100 ether);
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 50 ether}();
+
+		vm.prank(alice);
+		ggAVAX.approve(address(withdrawQueue), type(uint256).max);
+
+		vm.prank(alice);
+		uint256 requestId = withdrawQueue.requestUnstake(20 ether);
+
+		// Reduce ggAVAX liquidity to force deposit to ggAVAX
+		// Will result in 10 AVAX in ggAVAX. Need 10 AVAX to cover request
+		vm.startPrank(guardian);
+		ggAVAX.grantRole(ggAVAX.STAKER_ROLE(), guardian);
+		dao.setWithdrawForDelegationEnabled(true);
+		ggAVAX.withdrawForStaking(40 ether, bytes32("REDUCE_LIQUIDITY"));
+		vm.stopPrank();
+
+		// Store initial balance to verify liquidity calculation
+		uint256 ggAVAXAvailableBefore = ggAVAX.amountAvailableForStaking();
+
+		// calculate actual amount needed to deposit.
+		uint256 nextRequestAmount = withdrawQueue.getNextPendingRequestAmount();
+		uint256 feeAmount = dao.getFeeBips();
+		uint256 scaleFactor = uint256(1 ether).mulDivUp(10000, 10000 - feeAmount);
+		uint256 scaledNextRequestAmount = nextRequestAmount.mulWadUp(scaleFactor);
+		uint256 actualAmountNeeded = scaledNextRequestAmount - ggAVAXAvailableBefore;
+
+		uint256 rewardsRatio = 0.3 ether;
+		uint256 rewardAmount = actualAmountNeeded.mulWadUp(rewardsRatio);
+		uint256 baseAmount = actualAmountNeeded - rewardAmount;
+
+		// Perform the deposit with 70% base, 30% reward ratio
+		vm.deal(charlie, actualAmountNeeded);
+		vm.prank(charlie);
+		withdrawQueue.depositFromStaking{value: actualAmountNeeded}(baseAmount, rewardAmount, bytes32("FEE_TEST"));
+
+		// Verify the request was fulfilled - this proves the fee calculation worked
+		assertTrue(withdrawQueue.isFulfilledRequest(requestId), "Request should be fulfilled with proper fee accounting");
+
+		assertEq(withdrawQueue.getNextPendingRequestAmount(), 0, "No pending requests should remain after proper fee accounting");
+
+		// Verify that the scaling worked by checking that enough liquidity was added
+		// Even though fees were deducted, we should have sufficient liquidity
+		uint256 ggAVAXAvailableAfter = ggAVAX.amountAvailableForStaking();
+		assertTrue(ggAVAXAvailableAfter >= 0, "ggAVAX should maintain liquidity after fee-adjusted deposit");
+	}
+
 }
 
 // Malicious contract that attempts reentrancy

--- a/test/unit/WithdrawQueue.t.sol
+++ b/test/unit/WithdrawQueue.t.sol
@@ -34,7 +34,13 @@ contract WithdrawQueueTest is BaseTest {
 		// Deploy WithdrawQueue
 		vm.startPrank(guardian);
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(
+			WithdrawQueue.initialize.selector,
+			address(ggAVAX),
+			address(store),
+			UNSTAKE_DELAY,
+			EXPIRATION_DELAY
+		);
 
 		TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), initData);
 
@@ -114,7 +120,13 @@ contract WithdrawQueueTest is BaseTest {
 	function testInitializationEvent() public {
 		// Deploy a new WithdrawQueue to test the initialization event
 		WithdrawQueue newWithdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(
+			WithdrawQueue.initialize.selector,
+			address(ggAVAX),
+			address(store),
+			UNSTAKE_DELAY,
+			EXPIRATION_DELAY
+		);
 
 		// Expect the ContractInitialized event
 		vm.expectEmit(true, false, false, true);
@@ -168,7 +180,7 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(withdrawQueue.isRequestPending(requestId), true);
 
 		// Check user requests mapping
-		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice);
+		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice, 0, 0);
 		assertEq(userRequests.length, 1);
 		assertEq(userRequests[0], requestId);
 	}
@@ -212,7 +224,7 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(requestId1, 0);
 		assertEq(requestId2, 1);
 
-		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice);
+		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice, 0, 0);
 		assertEq(userRequests.length, 2);
 		assertEq(userRequests[0], requestId1);
 		assertEq(userRequests[1], requestId2);
@@ -1155,7 +1167,7 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(withdrawQueue.getRequestInfo(requestId).requester, address(0));
 
 		// Verify user's request history was cleaned up
-		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice);
+		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice, 0, 0);
 		assertEq(userRequests.length, 0);
 	}
 
@@ -1195,7 +1207,7 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(withdrawQueue.getRequestInfo(requestId).requester, address(0));
 
 		// Verify user's request history was cleaned up
-		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice);
+		uint256[] memory userRequests = withdrawQueue.getRequestsByOwner(alice, 0, 0);
 		assertEq(userRequests.length, 0);
 	}
 
@@ -1625,7 +1637,7 @@ contract WithdrawQueueTest is BaseTest {
 		}
 
 		// Verify user has no more requests
-		assertEq(withdrawQueue.getRequestsByOwner(alice).length, 0);
+		assertEq(withdrawQueue.getRequestsByOwner(alice, 0, 0).length, 0);
 
 		// Verify pending and fulfilled queues are empty
 		assertEq(withdrawQueue.getPendingRequestsCount(), 0);
@@ -1655,7 +1667,7 @@ contract WithdrawQueueTest is BaseTest {
 		assertEq(cancelledCount, 3);
 
 		// User should still have 2 requests
-		assertEq(withdrawQueue.getRequestsByOwner(alice).length, 2);
+		assertEq(withdrawQueue.getRequestsByOwner(alice, 0, 0).length, 2);
 	}
 
 	function testCancelNonExistentRequest() public {
@@ -1843,7 +1855,13 @@ contract WithdrawQueueTest is BaseTest {
 		// Deploy a new WithdrawQueue with the malicious ggAVAX
 		WithdrawQueue maliciousQueue;
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(maliciousGGAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(
+			WithdrawQueue.initialize.selector,
+			address(maliciousGGAVAX),
+			address(store),
+			UNSTAKE_DELAY,
+			EXPIRATION_DELAY
+		);
 
 		TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), initData);
 
@@ -2011,7 +2029,7 @@ contract WithdrawQueueTest is BaseTest {
 		withdrawQueue.depositFromStaking{value: 3 ether}(baseAmt, rewardAmt, bytes32("HYP3_FIX_TEST"));
 	}
 
-		function testDepositFromStakingWithFeeCalculation() public {
+	function testDepositFromStakingWithFeeCalculation() public {
 		// Test that the fee calculation correctly ensures sufficient funds are deposited to TokenggAVAX
 
 		// Set a protocol fee for rewards (5% = 500 basis points)
@@ -2067,6 +2085,245 @@ contract WithdrawQueueTest is BaseTest {
 		assertTrue(ggAVAXAvailableAfter >= 0, "ggAVAX should maintain liquidity after fee-adjusted deposit");
 	}
 
+	function testGetRequestsByOwnerPagination() public {
+		// Setup: Alice deposits enough ggAVAX to create multiple requests
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 2000 ether}();
+
+		// Create 10 requests for Alice with different amounts
+		uint256[] memory expectedRequestIds = new uint256[](10);
+
+		vm.startPrank(alice);
+		for (uint256 i = 0; i < 10; i++) {
+			uint256 shares = (i + 1) * 10 ether; // 10, 20, 30, ..., 100 ether
+			ggAVAX.approve(address(withdrawQueue), shares);
+			expectedRequestIds[i] = withdrawQueue.requestUnstake(shares);
+		}
+		vm.stopPrank();
+
+		// Verify all requests were created correctly
+		assertEq(withdrawQueue.nextRequestId(), 10, "Should have created 10 requests");
+
+		_testBasicPagination(expectedRequestIds);
+		_testEdgeCases(expectedRequestIds);
+		_testConsistencyAndOverlaps(expectedRequestIds);
+		_testExpandedRequests(expectedRequestIds);
+	}
+
+	function _testBasicPagination(uint256[] memory expectedRequestIds) internal {
+		// Test 1: Get all requests with limit = 0 (should return all)
+		uint256[] memory allRequests = withdrawQueue.getRequestsByOwner(alice, 0, 0);
+		assertEq(allRequests.length, 10, "Should return all 10 requests when limit = 0");
+		for (uint256 i = 0; i < 10; i++) {
+			assertEq(allRequests[i], expectedRequestIds[i], "Request IDs should match expected order");
+		}
+
+		// Test 2: Test pagination with page size of 3
+		uint256[] memory page1 = withdrawQueue.getRequestsByOwner(alice, 0, 3);
+		uint256[] memory page2 = withdrawQueue.getRequestsByOwner(alice, 3, 3);
+		uint256[] memory page3 = withdrawQueue.getRequestsByOwner(alice, 6, 3);
+		uint256[] memory page4 = withdrawQueue.getRequestsByOwner(alice, 9, 3);
+
+		// Verify page sizes
+		assertEq(page1.length, 3, "Page 1 should have 3 items");
+		assertEq(page2.length, 3, "Page 2 should have 3 items");
+		assertEq(page3.length, 3, "Page 3 should have 3 items");
+		assertEq(page4.length, 1, "Page 4 should have 1 item (last page)");
+
+		// Verify page contents
+		for (uint256 i = 0; i < 3; i++) {
+			assertEq(page1[i], expectedRequestIds[i], "Page 1 content should match");
+			assertEq(page2[i], expectedRequestIds[i + 3], "Page 2 content should match");
+			assertEq(page3[i], expectedRequestIds[i + 6], "Page 3 content should match");
+		}
+		assertEq(page4[0], expectedRequestIds[9], "Page 4 content should match");
+
+		// Test 3: Test single item pagination
+		for (uint256 i = 0; i < 10; i++) {
+			uint256[] memory singleItem = withdrawQueue.getRequestsByOwner(alice, i, 1);
+			assertEq(singleItem.length, 1, "Should return exactly 1 item");
+			assertEq(singleItem[0], expectedRequestIds[i], "Single item should match expected");
+		}
+	}
+
+	function _testEdgeCases(uint256[] memory expectedRequestIds) internal {
+		// Test 4: Test large page size (larger than total)
+		uint256[] memory largePage = withdrawQueue.getRequestsByOwner(alice, 0, 20);
+		assertEq(largePage.length, 10, "Large page should be capped at total items");
+		for (uint256 i = 0; i < 10; i++) {
+			assertEq(largePage[i], expectedRequestIds[i], "Large page content should match");
+		}
+
+		// Test 5: Test offset at boundary
+		uint256[] memory boundaryPage = withdrawQueue.getRequestsByOwner(alice, 5, 10);
+		assertEq(boundaryPage.length, 5, "Boundary page should return remaining items");
+		for (uint256 i = 0; i < 5; i++) {
+			assertEq(boundaryPage[i], expectedRequestIds[i + 5], "Boundary page content should match");
+		}
+
+		// Test 6: Test offset beyond total (should return empty)
+		uint256[] memory emptyPage1 = withdrawQueue.getRequestsByOwner(alice, 10, 5);
+		uint256[] memory emptyPage2 = withdrawQueue.getRequestsByOwner(alice, 15, 1);
+		assertEq(emptyPage1.length, 0, "Should return empty array when offset >= total");
+		assertEq(emptyPage2.length, 0, "Should return empty array when offset > total");
+
+		// Test 7: Test with offset = total - 1 (last item)
+		uint256[] memory lastItem = withdrawQueue.getRequestsByOwner(alice, 9, 5);
+		assertEq(lastItem.length, 1, "Should return last item");
+		assertEq(lastItem[0], expectedRequestIds[9], "Last item should match");
+
+		// Test 8: Test empty results for different user
+		uint256[] memory bobRequests = withdrawQueue.getRequestsByOwner(bob, 0, 0);
+		assertEq(bobRequests.length, 0, "Bob should have no requests");
+	}
+
+	function _testConsistencyAndOverlaps(uint256[] memory expectedRequestIds) internal {
+		// Test 9: Test consistency across multiple calls
+		uint256[] memory consistency1 = withdrawQueue.getRequestsByOwner(alice, 2, 4);
+		uint256[] memory consistency2 = withdrawQueue.getRequestsByOwner(alice, 2, 4);
+		assertEq(consistency1.length, consistency2.length, "Consistent calls should return same length");
+		for (uint256 i = 0; i < consistency1.length; i++) {
+			assertEq(consistency1[i], consistency2[i], "Consistent calls should return same content");
+		}
+
+		// Test 10: Test partial page at the end
+		uint256[] memory partialEnd = withdrawQueue.getRequestsByOwner(alice, 8, 5);
+		assertEq(partialEnd.length, 2, "Should return remaining 2 items");
+		assertEq(partialEnd[0], expectedRequestIds[8], "First item should match");
+		assertEq(partialEnd[1], expectedRequestIds[9], "Second item should match");
+
+		// Test 11: Verify no overlap between adjacent pages
+		uint256[] memory adjacentPage1 = withdrawQueue.getRequestsByOwner(alice, 0, 4);
+		uint256[] memory adjacentPage2 = withdrawQueue.getRequestsByOwner(alice, 4, 4);
+
+		// Check no duplicates between pages
+		for (uint256 i = 0; i < adjacentPage1.length; i++) {
+			for (uint256 j = 0; j < adjacentPage2.length; j++) {
+				assertTrue(adjacentPage1[i] != adjacentPage2[j], "Adjacent pages should not overlap");
+			}
+		}
+	}
+
+	function _testExpandedRequests(uint256[] memory expectedRequestIds) internal {
+		// Test 12: Create additional requests and verify pagination still works
+		vm.startPrank(alice);
+		for (uint256 i = 0; i < 3; i++) {
+			uint256 shares = 5 ether;
+			ggAVAX.approve(address(withdrawQueue), shares);
+			withdrawQueue.requestUnstake(shares);
+		}
+		vm.stopPrank();
+
+		uint256[] memory expandedRequests = withdrawQueue.getRequestsByOwner(alice, 0, 0);
+		assertEq(expandedRequests.length, 13, "Should now have 13 total requests");
+
+		// Verify old requests are still in the same positions
+		for (uint256 i = 0; i < 10; i++) {
+			assertEq(expandedRequests[i], expectedRequestIds[i], "Original requests should maintain position");
+		}
+
+		// Test pagination on expanded set
+		uint256[] memory expandedPage1 = withdrawQueue.getRequestsByOwner(alice, 0, 5);
+		uint256[] memory expandedPage2 = withdrawQueue.getRequestsByOwner(alice, 5, 5);
+		uint256[] memory expandedPage3 = withdrawQueue.getRequestsByOwner(alice, 10, 5);
+
+		assertEq(expandedPage1.length, 5, "Expanded page 1 should have 5 items");
+		assertEq(expandedPage2.length, 5, "Expanded page 2 should have 5 items");
+		assertEq(expandedPage3.length, 3, "Expanded page 3 should have 3 items");
+	}
+
+	function testMinUnstakeOnBehalfOfAmt() public {
+		// Test initial value (should be 0.01 ether from initialization)
+		assertEq(withdrawQueue.getMinUnstakeOnBehalfOfAmt(), 0.01 ether);
+
+		// Test setter (only admin can set)
+		uint256 newMinAmt = 0.05 ether;
+		vm.prank(guardian);
+		withdrawQueue.setMinUnstakeOnBehalfOfAmt(newMinAmt);
+		assertEq(withdrawQueue.getMinUnstakeOnBehalfOfAmt(), newMinAmt);
+
+		// Test that non-admin cannot set
+		vm.prank(alice);
+		vm.expectRevert();
+		withdrawQueue.setMinUnstakeOnBehalfOfAmt(0.1 ether);
+	}
+
+	function testRequestUnstakeOnBehalfOfMinimumNotMet() public {
+		// Setup: alice deposits ggAVAX, bob will try to unstake on behalf of alice
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 1000 ether}();
+
+		uint256 tooSmallAmount = 0.005 ether; // Less than 0.01 ether minimum
+		vm.startPrank(bob);
+
+		// Bob should revert when trying to unstake less than minimum
+		vm.expectRevert(WithdrawQueue.MinimumSharesNotMet.selector);
+		withdrawQueue.requestUnstakeOnBehalfOf(tooSmallAmount, alice);
+
+		vm.stopPrank();
+	}
+
+	function testRequestUnstakeOnBehalfOfMinimumMet() public {
+		// Setup: alice deposits ggAVAX, then transfers some to bob so bob can unstake on behalf of alice
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 1000 ether}();
+
+		uint256 validAmount = 0.05 ether; // More than 0.01 ether minimum
+
+		// Alice transfers some ggAVAX to bob
+		vm.prank(alice);
+		ggAVAX.transfer(bob, validAmount);
+
+		uint256 bobSharesBefore = ggAVAX.balanceOf(bob);
+
+		// Bob approves withdraw queue to spend his ggAVAX
+		vm.prank(bob);
+		ggAVAX.approve(address(withdrawQueue), validAmount);
+
+		vm.startPrank(bob);
+		uint256 requestId = withdrawQueue.requestUnstakeOnBehalfOf(validAmount, alice);
+		vm.stopPrank();
+
+		// Verify the request was created successfully
+		WithdrawQueue.UnstakeRequest memory request = withdrawQueue.getRequestInfo(requestId);
+		assertEq(request.requester, alice); // alice should be the requester (beneficiary)
+		assertEq(request.shares, validAmount);
+		assertEq(request.requestTime, block.timestamp);
+		assertEq(request.claimableTime, block.timestamp + UNSTAKE_DELAY);
+		assertEq(request.expirationTime, block.timestamp + UNSTAKE_DELAY + EXPIRATION_DELAY);
+
+		// Verify shares were transferred from bob to withdraw queue
+		assertEq(ggAVAX.balanceOf(bob), bobSharesBefore - validAmount);
+		assertEq(ggAVAX.balanceOf(address(withdrawQueue)), validAmount);
+
+		// Verify request is pending
+		assertTrue(withdrawQueue.isRequestPending(requestId));
+	}
+
+	function testRequestUnstakeOnBehalfOfExactMinimum() public {
+		// Setup: alice deposits ggAVAX, then transfers to bob
+		vm.prank(alice);
+		ggAVAX.depositAVAX{value: 1000 ether}();
+
+		uint256 exactMinAmount = 0.01 ether; // Exactly the minimum
+
+		// Alice transfers ggAVAX to bob
+		vm.prank(alice);
+		ggAVAX.transfer(bob, exactMinAmount);
+
+		// Bob approves withdraw queue to spend his ggAVAX
+		vm.prank(bob);
+		ggAVAX.approve(address(withdrawQueue), exactMinAmount);
+
+		vm.startPrank(bob);
+		uint256 requestId = withdrawQueue.requestUnstakeOnBehalfOf(exactMinAmount, alice);
+		vm.stopPrank();
+
+		// Should succeed with exact minimum amount
+		WithdrawQueue.UnstakeRequest memory request = withdrawQueue.getRequestInfo(requestId);
+		assertEq(request.requester, alice);
+		assertEq(request.shares, exactMinAmount);
+	}
 }
 
 // Malicious contract that attempts reentrancy

--- a/test/unit/WithdrawQueueGasTests.t.sol
+++ b/test/unit/WithdrawQueueGasTests.t.sol
@@ -30,7 +30,7 @@ contract WithdrawQueueGasTests is BaseTest {
 		// Deploy WithdrawQueue
 		vm.startPrank(guardian);
 		WithdrawQueue withdrawQueueImpl = new WithdrawQueue();
-		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), UNSTAKE_DELAY, EXPIRATION_DELAY);
+		bytes memory initData = abi.encodeWithSelector(WithdrawQueue.initialize.selector, address(ggAVAX), address(store), UNSTAKE_DELAY, EXPIRATION_DELAY);
 		TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(address(withdrawQueueImpl), address(proxyAdmin), initData);
 		withdrawQueue = WithdrawQueue(payable(address(proxy)));
 

--- a/test/unit/WithdrawQueueGasTests.t.sol
+++ b/test/unit/WithdrawQueueGasTests.t.sol
@@ -40,8 +40,8 @@ contract WithdrawQueueGasTests is BaseTest {
 		ggAVAX.grantRole(ggAVAX.STAKER_ROLE(), backgroundJob);
 		withdrawQueue.grantRole(withdrawQueue.DEPOSITOR_ROLE(), backgroundJob);
 
-		// Set max pending requests limit to 25 for testing
-		withdrawQueue.setMaxPendingRequestsLimit(25);
+		// Set max requests per staking deposit to 25 for testing
+		withdrawQueue.setMaxRequestsPerStakingDeposit(25);
 
 		// Set reserve ratio to 0% for testing
 		store.setUint(keccak256("ProtocolDAO.TargetGGAVAXReserveRate"), 0);


### PR DESCRIPTION
## Quantstamp Audit of selected GoGoPool contracts
Quantstamp audited pstAVAX, ggAVAX and the WithdrawQueue focusing on new features added here https://github.com/multisig-labs/gogopool/pull/5

### HYP-1: Potentially stale prices due to unstripped yield
✅ Fixed
Followed the suggested remediation and this issue was fixed by calling `TokenpstAVAX::stripYield` anytime a user deposits or withdraws from `TokenpstAVAX`. This ensures that all users get an up to date exchange rate via burning excess vault shares in `pstAVAX`. 

### HYP-2: Possibility of Multiple Default Admin Entities and Incorrect Admin Transfer
✅ Fixed
We followed the suggested remediation and now revert calls to `TokenggAVAX::grantRole` if the role that's granted is the `DEFAULT_ADMIN_ROLE`. We also removed the `TokenggAVAX::renounceAdmin` function to ensure that the `pendingAdmin` always finalizes the admin transfer

### HYP-3: Potential Reverts Due to Underflows in `depositFromStaking()`
✅ Fixed
In `WithdrawQueue::depositFromStaking` we're now checking for potential underflows to the `baseAmt` and `rewardAmt` parameters. 

### HYP-4: Consider Adding Rate Limiting Mechanisms To Protect Against Rogue Trusted Entities
⚠️ Acknowledged
We've decided not to address this concern at the moment, we will have sufficient protection for the accounts that have access to call `TokenggAVAX::withdrawForStaking`. There are two methods, one that is protected by `onlyRegisteredNetworkContract("MinipoolManager")` and a second that's protected by the `STAKER_ROLE`. We trust our storage contract setup to protect an address from becoming a registered network contract. And the `STAKER_ROLE` account will be carefully controlled, with external limits and access features that will allow us to quickly disable if it were to be compromised. 

### HYP-5: Risk of duplicate initialization
⚠️ Acknowledged
Our initializers don't perform any chained actions, so calling an `unchained` variant is not necessary. 

### HYP-6: Minor Potential DOS Vector on `requestsByOwner`
✅ Fixed
We implemented two fixes for this. First we followed the recommended remediation and added a minimum share amount to `requestUnstakeOnBehalfOf` to prevent griefing. Second we added pagination to `getRequestsByOwner`. 

### HYP-7: Assets Intended for ggAVAX Holders Repurposed for Fulfilling Withdrawal Requests
✅ Fixed
Followed the suggested remediation and are always donating `excessAVAX`

### HYP-8: Inconsistent Application of Sanity Checks on `withdrawForStaking` functions
⚠️ Acknowledged
We are checking the `amountAvailableForStaking` in the `MinipoolManager` where it calls to `TokenggAVAX::withdrawForStaking`. 

### HYP-9: `WithdrawQueue::depositFromStaking` Can Revert in Certain States
✅ Fixed
We followed the remediation, and are now calculating and covering the fee that `TokenggAVAX` takes when depositing rewards.

### HYP-10: Potential Reverts of `TokenpstAVAX::getExcessShares` due to underflow
✅ Fixed
We followed the recommended remediation and fixed by returning 0 when `pstAVAXVaultShares * ggAVAXTotalAssets < totalPstTokens * ggAVAXTotalShares`

### HYP-11: Improvements to `try-catch` Logic in `WithdrawQueue::depositFromStaking`
✅ Fixed
Followed the recommended remediation and throw a new error from `TokenggAVAX::redeemAVAX` that we check for in `WithdrawQueue::depositFromStaking`. That error is now the only graceful way to exit the loop

### S-1: Changes to pause modifier
⚠️ Acknowledged 
We're not changing the pause interaction here

### S-2: Assure `maxPendingRequestsLimit` is Used Properly
✅ Fixed
This variable was poorly named, it actually refers to the amount of requests we process in one deposit in `WithdrawQueue::depositFromStaking`. The variable has been renamed to `maxRequestsPerStakingDeposit`

### S-3: Remove duplicate code using internal functions
✅ Fixed
Following the recommended remediation we've created internal functions to combine the logic in `TokenggAVAX::depositFromStaking`, `TokenggAVAX::depositFromYield` and additionally `WithdrawQueue::requestUnstake` and `WithdrawQueue::requestUnstakeOnBehalfOf`

### S-4: Uncallable Functions defined
⚠️ Acknowledged
We're leaving these functions defined in `TokenggAVAX` for future implementations of `WithdrawQueue` that might utilize them. 

### S-5: General Code Improvements
✅ Fixed
Considered and resolved all four bullet points outlined. 
1. Unnecessary cleanup of data to be deleted in `WithdrawQueue::cancelRequest` and `WithdrawQueue::claimUnstake`
2. Removed assignment of `req.requester` in `WithdrawQueue::cancelRequest`
3. `TokenggAVAX::withdrawForStaking` fixed the external self call in fetching `amountAvailableForStaking`
4. Changed various function calls that aren't used internally from `public` to `external`

### S-6: Improvements to Event Emission / Error Handling
⚠️ Acknowledged
We've elected not to make any changes to the events suggested here. 
1. `TokenggAVAX::amountAvailableForStaking` over-allocation is implicitly understood if the `amountAvailbleForStaking` returns as 0
2. `TokenggAVAX::withdrawAVAX, redeemAVAX` I'd rather not pass the requester through to these functions for the particular `WithdrawQueue` use case
3. `TokenpstAVAX::getExcessShares` problematic liquidity scenario where `ggAVAXTotalAssets <= totalPstTokens` can  happen when there have been no rewards to `TokenggAVAX`, and returning 0 excess shares in that case is appropriate
4. `WithdrawQueue::claimUnstake` event for `totalAllocatedFunds -= amount` underflowing should never happen as an invariant of the protocol, and if it does a revert due to underflow is appropriate to investigate the issue further. 